### PR TITLE
Setting docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Versioning and metadata
+.git
+.gitignore
+.dockerignore
+
+# Build dependencies
+dist
+node_modules
+
+# Environment (contains sensitive data)
+.env
+
+# Files not required for production
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Production Dockerfile
+# This Dockerfile allows to build a production Docker image of the NestJS application.
+# It can be used to Amazon ECS task definitions to launch containers.
+
+FROM node:16-alpine as builder
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci && npm cache clear --force
+
+COPY . .
+RUN npm run build && npm prune --production
+
+# ---
+
+FROM node:16-alpine
+
+ENV NODE_ENV production
+
+WORKDIR /app
+COPY --from=builder --chown=node:node /app/package*.json ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+
+EXPOSE 3000
+
+CMD [ "npm", "run", "start:prod" ]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,11 @@
+FROM node:16-alpine as builder
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm install && npm cache clear --force
+
+COPY . .
+
+EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -58,15 +58,66 @@ $ npm run test:e2e
 $ npm run test:cov
 ```
 
+# How to run
+
+Make sure node.js 16 is installed
+
+## Run the application in local
+
+1. Git clone this repo and cd into the directory.
+2. Install dependencies.
+
+```bash
+npm install
+```
+
+3. Run.
+
+```bash
+npm run start:dev
+```
+
+## Nestjs on Docker for Development
+
+1. Make sure postgres is running if this app needs it.
+2. Git clone this repo and cd into the directory.
+3. Run with `docker-compose`. docker-compose.dev.yml is intended for development environments.
+
+```bash
+docker-compose -f docker-compose.dev.yml up
+```
+
+## Nestjs on Docker for Development
+
+`.Dockerfile` is Production Dockerfile allows to build a production Docker image of the NestJS application.
+Amazon ECS uses this Docker image in task definitions to launch containers.
+DO NOT use for development usages, it may have dependencies with AWS services(ex. RDS).
+
+But when you needed to check this out,
+
+1. Make sure all necessary services are available.
+2. Git clone this repo and cd into the directory.
+3. Build image
+
+```bash
+docker build --tag zuzu-prod-server .
+```
+
+4. Run the container
+
+```bash
+docker run -p 3000:3000 -v $(pwd):/app zuzu-prod-server
+```
+
 ## Support
 
 Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
 
 ## Stay in touch
 
-- Author - [Kamil Myśliwiec](https://kamilmysliwiec.com)
-- Website - [https://nestjs.com](https://nestjs.com/)
-- Twitter - [@nestframework](https://twitter.com/nestframework)
+-   Author - [Kamil Myśliwiec](https://kamilmysliwiec.com)
+-   Website - [https://nestjs.com](https://nestjs.com/)
+-   Twitter - [@nestframework](https://twitter.com/nestframework)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ npm run start:dev
 docker-compose -f docker-compose.dev.yml up
 ```
 
-## Nestjs on Docker for Development
+## Nestjs on Docker for Production
 
 `.Dockerfile` is Production Dockerfile allows to build a production Docker image of the NestJS application.  
 Amazon ECS uses this Docker image in task definitions to launch containers.  

--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ docker-compose -f docker-compose.dev.yml up
 
 ## Nestjs on Docker for Development
 
-`.Dockerfile` is Production Dockerfile allows to build a production Docker image of the NestJS application.
-Amazon ECS uses this Docker image in task definitions to launch containers.
+`.Dockerfile` is Production Dockerfile allows to build a production Docker image of the NestJS application.  
+Amazon ECS uses this Docker image in task definitions to launch containers.  
 DO NOT use for development usages, it may have dependencies with AWS services(ex. RDS).
 
-But when you needed to check this out,
+But when you need to check this out,
 
 1. Make sure all necessary services are available.
 2. Git clone this repo and cd into the directory.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,16 @@
+version: '3.9'
+
+services:
+  zuzu:
+    build:
+      context: .
+      dockerfile: ./Dockerfile.dev
+    container_name: zuzu-server
+    ports: 
+      - "3000:3000"
+    volumes:
+      - ./:/app
+    restart: always
+    environment:
+      - NODE_ENV=development
+    command: ["npm", "run", "start:dev"]


### PR DESCRIPTION
Related task: https://github.com/mash-up-kr/zuzu_Backend_Node/issues/1

- 개발 환경을 위한 Dockerfile, docker-compose 파일을 추가하였습니다. 
Because I Want to use Docker for local development also and **have dev and prod Docker images be as close as possible.**

- [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/)로 배포 환경을 위한 Dockerfile을 추가하였습니다. 
The multi-stage mechanism allows to build the application in a "builder" stage and then create a lightweight production
해당 Dockerfile은 추후 AWS ECS등 Container Service에서 사용될 것입니다. 

- 업데이트 사항에 대해 README를 작성하였습니다. 
