### PR TITLE
Feat: 카테고리별 술 조회에 pagination 추가

### DIFF
--- a/apps/api-server/src/modules/drinks/drinks.controller.spec.ts
+++ b/apps/api-server/src/modules/drinks/drinks.controller.spec.ts
@@ -43,11 +43,11 @@ describe('DrinksController', () => {
 
 		it('should call drinksService.findDrinksByCategory', async () => {
 			const name = Category['Beer'];
-			const offset = 0,
+			const page = 0,
 				length = 30;
-			await controller.findDrinksByCategory(name, offset, length);
-			expect(service.findDrinksByCategory).toHaveBeenCalledWith(name, offset, length);
-			expect(await controller.findDrinksByCategory(name, offset, length)).toEqual({
+			await controller.findDrinksByCategory(name, page, length);
+			expect(service.findDrinksByCategory).toHaveBeenCalledWith(name, page, length);
+			expect(await controller.findDrinksByCategory(name, page, length)).toEqual({
 				count: 1,
 				list: [
 					{

--- a/apps/api-server/src/modules/drinks/drinks.controller.spec.ts
+++ b/apps/api-server/src/modules/drinks/drinks.controller.spec.ts
@@ -31,31 +31,38 @@ describe('DrinksController', () => {
 
 	describe('findDrinksByCategory', () => {
 		it('should thorw BadRequestException Error if query is missing', async () => {
-			await expect(controller.findDrinksByCategory(undefined)).rejects.toThrow(BadRequestException);
+			await expect(controller.findDrinksByCategory(undefined, undefined, undefined)).rejects.toThrow(
+				BadRequestException,
+			);
 		});
 
 		it('should thorw BadRequestException Error if query is invalid', async () => {
 			const name = Category['InvalidDrinkCategory'];
-			await expect(controller.findDrinksByCategory(name)).rejects.toThrow(BadRequestException);
+			await expect(controller.findDrinksByCategory(name, 0, 30)).rejects.toThrow(BadRequestException);
 		});
 
 		it('should call drinksService.findDrinksByCategory', async () => {
 			const name = Category['Beer'];
-			await controller.findDrinksByCategory(name);
-			expect(service.findDrinksByCategory).toHaveBeenCalledWith(name);
-			expect(await controller.findDrinksByCategory(name)).toEqual([
-				{
-					id: 1,
-					createdAt: '2022-07-20T17:09:06.034Z',
-					updatedAt: '2022-07-20T17:09:06.034Z',
-					deletedAt: null,
-					name: 'beer test1',
-					abv: 0.1,
-					origin: '미국',
-					description: 'description test1',
-					image_url: 'https://zuzu-resource.s3.ap-northeast-2.amazonaws.com/drinks-category/test.png',
-				},
-			]);
+			const offset = 0,
+				length = 30;
+			await controller.findDrinksByCategory(name, offset, length);
+			expect(service.findDrinksByCategory).toHaveBeenCalledWith(name, offset, length);
+			expect(await controller.findDrinksByCategory(name, offset, length)).toEqual({
+				count: 1,
+				list: [
+					{
+						id: 1,
+						createdAt: '2022-07-20T17:09:06.034Z',
+						updatedAt: '2022-07-20T17:09:06.034Z',
+						deletedAt: null,
+						name: 'beer test1',
+						abv: 0.1,
+						origin: '미국',
+						description: 'description test1',
+						image_url: 'https://zuzu-resource.s3.ap-northeast-2.amazonaws.com/drinks-category/test.png',
+					},
+				],
+			});
 		});
 	});
 

--- a/apps/api-server/src/modules/drinks/drinks.controller.ts
+++ b/apps/api-server/src/modules/drinks/drinks.controller.ts
@@ -23,13 +23,13 @@ export class DrinksController {
 	@ApiDocs.findDrinksByCategory('카테고리별 술 상세 정보 조회')
 	public async findDrinksByCategory(
 		@Query('name') name: Category,
-		@Query('offset') offset: number,
+		@Query('page') page: number,
 		@Query('length') length: number,
 	) {
 		if (!name) {
 			throw new BadRequestException();
 		}
-		return await this.drinksService.findDrinksByCategory(name, offset, length);
+		return await this.drinksService.findDrinksByCategory(name, page, length);
 	}
 
 	@Get(':id')

--- a/apps/api-server/src/modules/drinks/drinks.controller.ts
+++ b/apps/api-server/src/modules/drinks/drinks.controller.ts
@@ -21,11 +21,15 @@ export class DrinksController {
 
 	@Get('/category')
 	@ApiDocs.findDrinksByCategory('카테고리별 술 상세 정보 조회')
-	public async findDrinksByCategory(@Query('name') name: Category) {
+	public async findDrinksByCategory(
+		@Query('name') name: Category,
+		@Query('offset') offset: number,
+		@Query('length') length: number,
+	) {
 		if (!name) {
 			throw new BadRequestException();
 		}
-		return await this.drinksService.findDrinksByCategory(name);
+		return await this.drinksService.findDrinksByCategory(name, offset, length);
 	}
 
 	@Get(':id')

--- a/apps/api-server/src/modules/drinks/drinks.service.ts
+++ b/apps/api-server/src/modules/drinks/drinks.service.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, Injectable, InternalServerErrorException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { QueryResult, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 
 import { Drink } from '@src/entities/drinks.entity';
 import { CreateDrinkDto } from './dto/create-drink.dto';

--- a/apps/api-server/src/modules/drinks/drinks.service.ts
+++ b/apps/api-server/src/modules/drinks/drinks.service.ts
@@ -59,10 +59,11 @@ export class DrinksService {
 
 	public async findDrinksByCategory(
 		category: string,
-		offset = 0,
+		page = 0,
 		length = 30,
-	): Promise<{ count: number; list: Drink[] }> {
+	): Promise<{ totalPageCount: number; list: Drink[] }> {
 		try {
+			console.log(category, page, length);
 			let queryBuilder = this.drinkRepository.createQueryBuilder('drink');
 
 			if (category !== 'All') {
@@ -72,13 +73,14 @@ export class DrinksService {
 			}
 
 			const count = await queryBuilder.getCount();
+			const totalPageCount = Math.ceil(count / length);
 			const drinksByCategory = await queryBuilder
 				.orderBy('drink.createdAt', 'DESC')
-				.skip(offset)
+				.skip((page - 1) * length)
 				.take(length)
 				.getMany();
 
-			return { count, list: drinksByCategory };
+			return { totalPageCount: totalPageCount, list: drinksByCategory };
 		} catch (error) {
 			throw new InternalServerErrorException(error.message, error);
 		}

--- a/apps/api-server/test/mock/drinks.mock.ts
+++ b/apps/api-server/test/mock/drinks.mock.ts
@@ -55,9 +55,9 @@ export const MockDrinksService = {
 	findDrinksByCategory: jest.fn((name) => {
 		if (Object.values(Category).includes(name as Category)) {
 			if (name === 'Beer') {
-				return [omit(mockDrinks[0], 'category')];
+				return { count: 1, list: [omit(mockDrinks[0], 'category')] };
 			} else if (name === 'Soju') {
-				return [omit(mockDrinks[1], 'category')];
+				return { count: 1, list: [omit(mockDrinks[1], 'category')] };
 			}
 		} else {
 			throw new BadRequestException();


### PR DESCRIPTION
카테고리별 술 조회에 pagination을 적용했습니다.

`category === ALL` 일 때 페이지네이션이 적용되지 않는 `findAllDrinks()`와 의존성이 있어서 category조건에 따른 queryBuilding으로 의존성을 제거해봤습니다

페이지네이션은 offset, length를 받는 방법과 page, length를 받는 방법, 커서를 이용한 방법 세 개가 있는 걸로 알고 있는데,
커서를 쓸 정도로 Create나 Delete가 빈번하진 않은 서비스라고 생각해서 남은 두 방법 중 첫번째 방법으로 구현해봤어요 의견 주시면 감사하겠습니답