### PR TITLE
Chore: Add ecs cd script to deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,70 @@
+name: Deploy to Amazon ECS
+
+on:
+    push:
+        branches: [main]
+
+jobs:
+    deploy:
+        name: Deploy
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Check out the repo
+              uses: actions/checkout@v2
+
+            - name: Create env.prod file
+              run: |
+                  touch .env.prod
+                  echo NODE_ENV=prod >> .env.prod
+                  echo PORT=${{secrets.PROD_PORT}} >> .env.prod
+                  echo DATABASE_USER=${{secrets.PROD_DATABASE_USER}} >> .env.prod
+                  echo DATABASE_PASSWORD=${{secrets.PROD_DATABASE_PASSWORD}} >> .env.prod
+                  echo DATABASE_HOST=${{secrets.PROD_DATABASE_HOST}} >> .env.prod
+                  echo DATABASE_PORT=${{secrets.PROD_DATABASE_PORT}} >> .env.prod
+                  echo DATABASE_DB=${{secrets.PROD_DATABASE_DB}} >> .env.prod
+                  echo POSTGRES_USER=${{secrets.PROD_POSTGRES_USER}} >> .env.prod
+                  echo POSTGRES_PASSWORD=${{secrets.PROD_POSTGRES_PASSWORD}} >> .env.prod
+                  echo POSTGRES_DB=${{secrets.PROD_POSTGRES_DB}} >> .env.prod
+                  echo KAKAO_CLIENT_ID=${{secrets.KAKAO_CLIENT_ID}} >> .env.prod
+                  echo KAKAO_CALLBACK_URL=${{secrets.PROD_KAKAO_CALLBACK_URL}} >> .env.prod
+                  echo JWT_ACCESS_TOKEN_SECRET=${{secrets.JWT_ACCESS_TOKEN_SECRET}} >> .env.prod
+                  echo JWT_REFRESH_TOKEN_EXPIRATION_TIME=${{secrets.JWT_REFRESH_TOKEN_EXPIRATION_TIME}} >> .env.prod
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v1
+              with:
+                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws-region: ap-northeast-2
+
+            - name: Login to Amazon ECR
+              id: login-ecr
+              uses: aws-actions/amazon-ecr-login@v1
+
+            - name: Build, tag, and push image to Amazon ECR
+              id: build-image
+              env:
+                  ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+                  ECR_REPOSITORY: proof-backend-node-img
+                  IMAGE_TAG: ${{ github.sha }}
+              # Build a docker container and
+              # push it to ECR so that it can be deployed to ECS.
+              run: |
+                  docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG . 
+                  docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG 
+                  echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+            - name: Fill in the new image ID in the Amazon ECS task definition
+              id: task-def
+              uses: aws-actions/amazon-ecs-render-task-definition@v1
+              with:
+                  task-definition: task-definition.json
+                  container-name: proof-backend-node-container
+                  image: ${{ steps.build-image.outputs.image }}
+
+            - name: Deploy Amazon ECS task definition
+              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+              with:
+                  task-definition: ${{ steps.task-def.outputs.task-definition }}
+                  service: proof-ecs-service
+                  cluster: Proof-Ecs-Cluster
+                  wait-for-service-stability: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,8 +28,13 @@ jobs:
                   echo POSTGRES_DB=${{secrets.PROD_POSTGRES_DB}} >> .env.prod
                   echo KAKAO_CLIENT_ID=${{secrets.KAKAO_CLIENT_ID}} >> .env.prod
                   echo KAKAO_CALLBACK_URL=${{secrets.PROD_KAKAO_CALLBACK_URL}} >> .env.prod
+                  echo ADMIN_EMAIL=${{secrets.ADMIN_EMAIL}} >> .env.prod
                   echo JWT_ACCESS_TOKEN_SECRET=${{secrets.JWT_ACCESS_TOKEN_SECRET}} >> .env.prod
+                  echo JWT_ACCESS_TOKEN_EXPIRATION_TIME=${{secrets.JWT_ACCESS_TOKEN_EXPIRATION_TIME}} >> .env.prod
+                  echo JWT_ACCESS_TOKEN_EXPIRATION_TIME_ADMIN=${{secrets.JWT_ACCESS_TOKEN_EXPIRATION_TIME_ADMIN}} >> .env.prod
+                  echo JWT_REFRESH_TOKEN_SECRET=${{secrets.JWT_REFRESH_TOKEN_SECRET}} >> .env.pod
                   echo JWT_REFRESH_TOKEN_EXPIRATION_TIME=${{secrets.JWT_REFRESH_TOKEN_EXPIRATION_TIME}} >> .env.prod
+
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v1
               with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ COPY --from=builder --chown=node:node /app/package.json ./
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
 
+WORKDIR /app/dist/apps/api-server/
 EXPOSE 3000
 
-CMD [ "node", "dist/main" ]
+CMD [ "node", "main.js" ]

--- a/README.md
+++ b/README.md
@@ -114,13 +114,15 @@ But when you need to check this out,
 3. Build image
 
 ```bash
-docker build --tag zuzu-prod-server .
+docker build --tag proof-backend-node-img .
+or
+docker build --platform=linux/amd64 -t proof-backend-node-img .  (if you use MAC m1)
 ```
 
 4. Run the container
 
 ```bash
-docker run -p 3000:3000 -v $(pwd):/app --env-file=./.env.prod zuzu-prod-server
+docker run -p 3000:3000 --env-file=./.env.prod proof-backend-node-img
 ```
 
 ## Support

--- a/task-definition.json
+++ b/task-definition.json
@@ -1,0 +1,39 @@
+{
+	"family": "proof-task-def",
+	"taskRoleArn": "arn:aws:iam::119011927775:role/ecsTaskExecutionRole",
+	"executionRoleArn": "arn:aws:iam::119011927775:role/ecsTaskExecutionRole",
+	"networkMode": null,
+	"containerDefinitions": [
+		{
+			"name": "proof-backend-node-container",
+			"image": "proof-backend-node-img",
+			"portMappings": [
+				{
+					"hostPort": 3000,
+					"protocol": "tcp",
+					"containerPort": 3000
+				}
+			],
+			"environmentFiles": [
+				{
+					"value": "arn:aws:s3:::zuzu-resource/proof.env",
+					"type": "s3"
+				}
+			],
+			"memory": 491,
+			"memoryReservation": 491,
+			"logConfiguration": {
+				"logDriver": "awslogs",
+				"secretOptions": null,
+				"options": {
+					"awslogs-group": "/ecs/proof-task-def",
+					"awslogs-region": "ap-northeast-2",
+					"awslogs-stream-prefix": "ecs"
+				}
+			}
+		}
+	],
+	"requiresCompatibilities": ["EC2"],
+	"cpu": "512",
+	"memory": "491"
+}


### PR DESCRIPTION
### Done
- aws console에서 ECS (used ec2 requiresCompatibilities) 에 배포하였습니다. (http://proof-alb-962355842.ap-northeast-2.elb.amazonaws.com:3000/api-docs/) 

- 그리고 CICD를 위한 github actions, task-definition script를 작성하였습니다. 
  - 하면서 가장 많은 실패 원인은 
  service  proof-ecs-service was unable to place a task because no container instance met all of its requirements. The closest matching container-instance 어쩌구 has **insufficient memory available.**    
service proof-ecs-service was unable to place a task because no container instance met all of its requirements. The closest matching container-instance 어쩌구 has **insufficient CPU units available.** For more information, see the [Troubleshooting section](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/troubleshooting.html).

이었습니다. 저희가 비용문제로 t2.micro를 사용하고 있는 많큼 배포시 blue/green은 일시적으로 2배씩 쓰게 되므로 이 문제를 계속 잡고있기엔 적합하지 않다고 생각하여 일단 rolling update 방식의 배포 방식으로 작성하였습니다.  

- github actions로 CD 성공 하는 것 확인하였고(https://github.com/mash-up-kr/proof_Backend_Node/runs/7823406258?check_suite_focus=true) , 이 PR에선     push: branches: [main] 만 남겨두어 main 으로 머지시 배포되도록 수정하였습니다. 

- 지금까지 테스트/시행착오로 생성된 많은 사용되지 않는 aws service를 정리했습니다. 

### TODO 
- 이 PR까지 develop에 머지되면, 지금까지 develop에 작업 되어있는 것까지 main에 머지해서 배포하려고 합니다. 
- 그리고 ec2 배포 서버는 내리고, 지금http://server.mashup-proof.click/ 을 이 ECS alb의 도메인으로 갈아끼우고자 합니다. **(지금 두배로 돈이 들어가고 있으니 최대한 빨리)**
