### PR TITLE
Feat: Add review_result property to Drink table & Add GET /drinks-evaluation api

### DIFF
--- a/apps/api-server/src/app.module.ts
+++ b/apps/api-server/src/app.module.ts
@@ -2,14 +2,15 @@ import { Module } from '@nestjs/common';
 
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { AuthModule } from './modules/auth/auth.module';
 import { ConfigModule } from './config/config.module';
 import { DatabaseModule } from './database/database.module';
+import { AuthModule } from './modules/auth/auth.module';
 import { DrinksCategoryModule } from './modules/drinks-category/drinks-category.module';
+import { DrinksEvaluationModule } from './modules/drinks-evaluation/drinks-evaluation.module';
 import { DrinksModule } from './modules/drinks/drinks.module';
 import { ReviewsModule } from './modules/reviews/reviews.module';
-import { UsersModule } from './modules/users/users.module';
 import { UsersProfileModule } from './modules/users-profile/users-profile.module';
+import { UsersModule } from './modules/users/users.module';
 import { WorldcupModule } from './modules/worldcup/worldcup.module';
 
 @Module({
@@ -23,6 +24,7 @@ import { WorldcupModule } from './modules/worldcup/worldcup.module';
 		UsersProfileModule,
 		WorldcupModule,
 		ReviewsModule,
+		DrinksEvaluationModule,
 	],
 	controllers: [AppController],
 	providers: [AppService],

--- a/apps/api-server/src/entities/drinks.entity.ts
+++ b/apps/api-server/src/entities/drinks.entity.ts
@@ -2,10 +2,11 @@ import { ApiProperty } from '@nestjs/swagger';
 
 import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
 
+import { DEFAULT_DRINK_REVIEW_RESULT } from '@src/modules/drinks/dto/drink.constants';
+import { IsNotEmpty, IsNumber } from 'class-validator';
+import { CommonEntity } from './common.entity';
 import { DrinksCategory } from './drinks-category.entity';
 import { Review } from './reviews.entity';
-import { CommonEntity } from './common.entity';
-import { IsNotEmpty, IsNumber } from 'class-validator';
 
 @Entity()
 export class Drink extends CommonEntity {
@@ -42,6 +43,12 @@ export class Drink extends CommonEntity {
 		default: 'https://zuzu-resource.s3.ap-northeast-2.amazonaws.com/drinks-category/beer.png',
 	}) // TODO: Change default img url to the real one after DES team give the real img.
 	image_url: string;
+
+	@ApiProperty({
+		description: '술 리뷰에 대한 json 데이터',
+	})
+	@Column({ type: 'jsonb', nullable: false, default: () => `'${DEFAULT_DRINK_REVIEW_RESULT}'::jsonb` })
+	review_result: string;
 
 	@ApiProperty({ example: 1 })
 	@IsNumber()

--- a/apps/api-server/src/modules/drinks-evaluation/drinks-evaluation.controller.spec.ts
+++ b/apps/api-server/src/modules/drinks-evaluation/drinks-evaluation.controller.spec.ts
@@ -1,0 +1,29 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Drink } from '@src/entities/drinks.entity';
+import { MockDrinksEvaluationRepository } from '../../../test/mock/drinks-evaluation.mock';
+import { DrinksEvaluationController } from './drinks-evaluation.controller';
+import { DrinksEvaluationService } from './drinks-evaluation.service';
+
+describe('DrinksEvaluationController', () => {
+	let controller: DrinksEvaluationController;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			controllers: [DrinksEvaluationController],
+			providers: [
+				DrinksEvaluationService,
+				{
+					provide: getRepositoryToken(Drink),
+					useClass: MockDrinksEvaluationRepository,
+				},
+			],
+		}).compile();
+
+		controller = module.get<DrinksEvaluationController>(DrinksEvaluationController);
+	});
+
+	it('should be defined', () => {
+		expect(controller).toBeDefined();
+	});
+});

--- a/apps/api-server/src/modules/drinks-evaluation/drinks-evaluation.controller.ts
+++ b/apps/api-server/src/modules/drinks-evaluation/drinks-evaluation.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { ApiDocs } from './drinks-evaluation.docs';
+import { DrinksEvaluationService } from './drinks-evaluation.service';
+
+@ApiTags('Drinks-evaluation')
+@Controller('drinks-evaluation')
+export class DrinksEvaluationController {
+	constructor(private readonly drinksEvaluationService: DrinksEvaluationService) {}
+
+	@Get(':id')
+	@ApiDocs.findDrinkEvaluation('술 리뷰 평가')
+	public async findDrinkEvaluation(@Param('id') id: number) {
+		return await this.drinksEvaluationService.findDrinkEvaluation(id);
+	}
+}

--- a/apps/api-server/src/modules/drinks-evaluation/drinks-evaluation.docs.ts
+++ b/apps/api-server/src/modules/drinks-evaluation/drinks-evaluation.docs.ts
@@ -1,0 +1,22 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+import { SwaggerMethodDoc } from '@src/swagger/swagger-method-doc-type';
+import { DrinksEvaluationController } from './drinks-evaluation.controller';
+
+export const ApiDocs: SwaggerMethodDoc<DrinksEvaluationController> = {
+	findDrinkEvaluation(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: '술 리뷰 기반의 평가 데이터',
+			}),
+			ApiResponse({
+				status: 200,
+				description: '',
+				// type: '',
+			}),
+			ApiBearerAuth('Authorization'),
+		);
+	},
+};

--- a/apps/api-server/src/modules/drinks-evaluation/drinks-evaluation.module.ts
+++ b/apps/api-server/src/modules/drinks-evaluation/drinks-evaluation.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Drink } from '@src/entities/drinks.entity';
+import { DrinksEvaluationController } from './drinks-evaluation.controller';
+import { DrinksEvaluationService } from './drinks-evaluation.service';
+
+@Module({
+	imports: [TypeOrmModule.forFeature([Drink])],
+	controllers: [DrinksEvaluationController],
+	providers: [DrinksEvaluationService],
+})
+export class DrinksEvaluationModule {}

--- a/apps/api-server/src/modules/drinks-evaluation/drinks-evaluation.service.spec.ts
+++ b/apps/api-server/src/modules/drinks-evaluation/drinks-evaluation.service.spec.ts
@@ -1,0 +1,27 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Drink } from '@src/entities/drinks.entity';
+import { MockDrinksEvaluationRepository } from '../../../test/mock/drinks-evaluation.mock';
+import { DrinksEvaluationService } from './drinks-evaluation.service';
+
+describe('DrinksEvaluationService', () => {
+	let service: DrinksEvaluationService;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				DrinksEvaluationService,
+				{
+					provide: getRepositoryToken(Drink),
+					useClass: MockDrinksEvaluationRepository,
+				},
+			],
+		}).compile();
+
+		service = module.get<DrinksEvaluationService>(DrinksEvaluationService);
+	});
+
+	it('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/apps/api-server/src/modules/drinks-evaluation/drinks-evaluation.service.ts
+++ b/apps/api-server/src/modules/drinks-evaluation/drinks-evaluation.service.ts
@@ -1,0 +1,122 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { Drink } from '@src/entities/drinks.entity';
+import { Companion, Mood, Time, Weather } from '@src/types/reviews.types';
+import { DrinksEvaluationReseponseDto } from './dto/drinks-evaluation-response.dto';
+import { DrinksEvaluationTasteDto } from './dto/drinks-evaluation-taste.dto';
+
+@Injectable()
+export class DrinksEvaluationService {
+	constructor(
+		@InjectRepository(Drink)
+		private readonly drinkRepository: Repository<Drink>,
+	) {}
+
+	async findDrinkEvaluation(drinkId: number) {
+		const reviewResultQuery = await this.drinkRepository
+			.createQueryBuilder('drink')
+			.select(`(drink.review_result)::JSONB AS review_result`)
+			.where('drink.id = :id', { id: drinkId })
+			.getRawOne();
+
+		const reviewResult = reviewResultQuery.review_result;
+
+		const result = new DrinksEvaluationReseponseDto();
+
+		// max key 구하기
+		result.weather = this.findMaxValuesKey(reviewResult.weather) as Weather;
+		result.time = this.findMaxValuesKey(reviewResult.time) as Time;
+		result.companion = this.findMaxValuesKey(reviewResult.companion) as Companion;
+		result.mood = this.findMaxValuesKey(reviewResult.mood) as Mood;
+		if (reviewResult.spot['1'] !== 0 || reviewResult.spot['2'] !== 0 || reviewResult.spot['3'] !== 0)
+			result.spot = this.findMaxValuesKey(reviewResult.spot) as string;
+
+		// 각 개수 구하기
+		const isHeavyResult = this.quantifyDrinksExpression(reviewResult.is_heavy);
+		result.is_heavy.Light = isHeavyResult.group1;
+		result.is_heavy.Heavy = isHeavyResult.group2;
+		const isBitterResult = this.quantifyDrinksExpression(reviewResult.is_bitter);
+		result.is_bitter.Sweet = isBitterResult.group1;
+		result.is_bitter.Bitter = isBitterResult.group2;
+		const isStrongResult = this.quantifyDrinksExpression(reviewResult.is_strong);
+		result.is_strong.Mild = isStrongResult.group1;
+		result.is_strong.Strong = isStrongResult.group2;
+		const isBurningResult = this.quantifyDrinksExpression(reviewResult.is_burning);
+		result.is_burning.Smooth = isBurningResult.group1;
+		result.is_burning.Burning = isBurningResult.group2;
+
+		// taste 상위 세개 (전체 리뷰 개수 필요 - 합)
+		const tasteResult = reviewResult.taste;
+		result.taste = this.findTopTastes(tasteResult);
+
+		// 안주 최고 3개 (max)
+		const pairingResult = reviewResult.pairing;
+		this.findTopPairings(pairingResult, result.pairing);
+		return result;
+	}
+
+	private findMaxValuesKey(reviewResultObj: any): Weather | Time | Companion | Mood | string {
+		const reviewResulttArr = Object.keys(reviewResultObj) as Weather[] | Time[] | Companion[] | Mood[] | string[];
+		let maxKey: Weather | Time | Companion | Mood | string = reviewResulttArr[0];
+		let maxVal: number = reviewResultObj[reviewResulttArr[0]];
+		for (const key in reviewResultObj) {
+			if (reviewResultObj[key] > maxVal) {
+				maxKey = key as Weather | Time | Companion | Mood | string;
+				maxVal = reviewResultObj[key];
+			}
+		}
+		return maxKey;
+	}
+
+	// test
+	private quantifyDrinksExpression(reviewResultObj: any) {
+		let group1 = 0;
+		let group2 = 0;
+		for (const key in reviewResultObj) {
+			if (Number(key) <= 3) group1 += reviewResultObj[key];
+			else group2 += reviewResultObj[key];
+		}
+		return { group1, group2 };
+	}
+
+	private findTopTastes(reviewResultObj: any) {
+		let reviewNum = 0;
+		let tasteArr = [];
+		for (const key in reviewResultObj) {
+			reviewNum += reviewResultObj[key];
+			if (reviewResultObj[key] > 0)
+				tasteArr.push(
+					new DrinksEvaluationTasteDto({
+						taste_name: key,
+						percent: reviewResultObj[key],
+					}),
+				);
+		}
+		tasteArr = tasteArr.sort((a, b) => a.percent - b.percent);
+		const sliceIndex: number = tasteArr.length >= 3 ? 3 : tasteArr.length;
+		tasteArr = tasteArr.slice(-sliceIndex);
+		tasteArr.map((element) => {
+			element.percent = String(Math.floor((element.percent / reviewNum) * 100)) + '%';
+			return element;
+		});
+		return tasteArr;
+	}
+
+	private findTopPairings(reviewResultObj: any, pairingArr): any {
+		let sortedPairingResult = [];
+		for (const key in reviewResultObj) {
+			if (reviewResultObj[key] > 0) sortedPairingResult.push([key, reviewResultObj[key]]);
+		}
+
+		sortedPairingResult.sort((a, b) => {
+			return a[1] - b[1];
+		});
+		const sliceIndex: number = sortedPairingResult.length >= 3 ? 3 : sortedPairingResult.length;
+		sortedPairingResult = sortedPairingResult.slice(-sliceIndex);
+		for (const item of sortedPairingResult) {
+			pairingArr.push(item[0]);
+		}
+	}
+}

--- a/apps/api-server/src/modules/drinks-evaluation/drinks-evaluation.service.ts
+++ b/apps/api-server/src/modules/drinks-evaluation/drinks-evaluation.service.ts
@@ -16,17 +16,17 @@ export class DrinksEvaluationService {
 
 	async findDrinkEvaluation(drinkId: number) {
 		try {
-			const reviewResultRow = await this.drinkRepository
+			const drink = await this.drinkRepository
 				.createQueryBuilder('drink')
 				.select(`(drink.review_result)::JSONB AS review_result`)
 				.where('drink.id = :id', { id: drinkId })
 				.getRawOne();
 
-			if (!reviewResultRow) throw new BadRequestException('존재하지 않는 술입니다.');
-			if (!reviewResultRow.review_result.has_review) return { result: null };
+			if (!drink) throw new BadRequestException('존재하지 않는 술입니다.');
+			if (!drink.review_result.has_review) return { result: null };
 
 			const result = new DrinksEvaluationReseponseDto();
-			const reviewResult = reviewResultRow.review_result;
+			const reviewResult = drink.review_result;
 
 			// max key 구하기
 			result.weather = this.findMaxValuesKey(reviewResult.weather) as Weather;

--- a/apps/api-server/src/modules/drinks-evaluation/drinks-evaluation.service.ts
+++ b/apps/api-server/src/modules/drinks-evaluation/drinks-evaluation.service.ts
@@ -22,7 +22,6 @@ export class DrinksEvaluationService {
 			.getRawOne();
 
 		const reviewResult = reviewResultQuery.review_result;
-
 		const result = new DrinksEvaluationReseponseDto();
 
 		// max key 구하기
@@ -31,21 +30,10 @@ export class DrinksEvaluationService {
 		result.companion = this.findMaxValuesKey(reviewResult.companion) as Companion;
 		result.mood = this.findMaxValuesKey(reviewResult.mood) as Mood;
 		if (reviewResult.spot['1'] !== 0 || reviewResult.spot['2'] !== 0 || reviewResult.spot['3'] !== 0)
-			result.spot = this.findMaxValuesKey(reviewResult.spot) as string;
+			result.spot = (this.findMaxValuesKey(reviewResult.spot) as string) + '차';
 
 		// 각 개수 구하기
-		const isHeavyResult = this.quantifyDrinksExpression(reviewResult.is_heavy);
-		result.is_heavy.Light = isHeavyResult.group1;
-		result.is_heavy.Heavy = isHeavyResult.group2;
-		const isBitterResult = this.quantifyDrinksExpression(reviewResult.is_bitter);
-		result.is_bitter.Sweet = isBitterResult.group1;
-		result.is_bitter.Bitter = isBitterResult.group2;
-		const isStrongResult = this.quantifyDrinksExpression(reviewResult.is_strong);
-		result.is_strong.Mild = isStrongResult.group1;
-		result.is_strong.Strong = isStrongResult.group2;
-		const isBurningResult = this.quantifyDrinksExpression(reviewResult.is_burning);
-		result.is_burning.Smooth = isBurningResult.group1;
-		result.is_burning.Burning = isBurningResult.group2;
+		this.quantifyDrinksExpression(result, reviewResult);
 
 		// taste 상위 세개 (전체 리뷰 개수 필요 - 합)
 		const tasteResult = reviewResult.taste;
@@ -70,15 +58,20 @@ export class DrinksEvaluationService {
 		return maxKey;
 	}
 
-	// test
-	private quantifyDrinksExpression(reviewResultObj: any) {
-		let group1 = 0;
-		let group2 = 0;
-		for (const key in reviewResultObj) {
-			if (Number(key) <= 3) group1 += reviewResultObj[key];
-			else group2 += reviewResultObj[key];
+	private quantifyDrinksExpression(result, reviewResult) {
+		for (let i = 1; i <= 6; i++) {
+			if (i <= 3) {
+				result.is_heavy.Light += reviewResult.is_heavy[String(i)];
+				result.is_bitter.Sweet += reviewResult.is_bitter[String(i)];
+				result.is_strong.Mild += reviewResult.is_strong[String(i)];
+				result.is_burning.Smooth += reviewResult.is_burning[String(i)];
+			} else {
+				result.is_heavy.Heavy += reviewResult.is_heavy[String(i)];
+				result.is_bitter.Bitter += reviewResult.is_bitter[String(i)];
+				result.is_strong.Strong += reviewResult.is_strong[String(i)];
+				result.is_burning.Burning += reviewResult.is_burning[String(i)];
+			}
 		}
-		return { group1, group2 };
 	}
 
 	private findTopTastes(reviewResultObj: any) {

--- a/apps/api-server/src/modules/drinks-evaluation/drinks-evaluation.service.ts
+++ b/apps/api-server/src/modules/drinks-evaluation/drinks-evaluation.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
 import { Drink } from '@src/entities/drinks.entity';
-import { Companion, Mood, Time, Weather } from '@src/types/reviews.types';
+import { Companion, Mood, ReviewResultItem, Spot, Time, Weather } from '@src/types/reviews.types';
 import { DrinksEvaluationReseponseDto } from './dto/drinks-evaluation-response.dto';
 import { DrinksEvaluationTasteDto } from './dto/drinks-evaluation-taste.dto';
 
@@ -30,7 +30,7 @@ export class DrinksEvaluationService {
 		result.companion = this.findMaxValuesKey(reviewResult.companion) as Companion;
 		result.mood = this.findMaxValuesKey(reviewResult.mood) as Mood;
 		if (reviewResult.spot['1'] !== 0 || reviewResult.spot['2'] !== 0 || reviewResult.spot['3'] !== 0)
-			result.spot = (this.findMaxValuesKey(reviewResult.spot) as string) + '차';
+			result.spot = (this.findMaxValuesKey(reviewResult.spot) as Spot) + '차';
 
 		// 각 개수 구하기
 		this.quantifyDrinksExpression(result, reviewResult);
@@ -45,13 +45,13 @@ export class DrinksEvaluationService {
 		return result;
 	}
 
-	private findMaxValuesKey(reviewResultObj: any): Weather | Time | Companion | Mood | string {
-		const reviewResulttArr = Object.keys(reviewResultObj) as Weather[] | Time[] | Companion[] | Mood[] | string[];
-		let maxKey: Weather | Time | Companion | Mood | string = reviewResulttArr[0];
+	private findMaxValuesKey(reviewResultObj: any): ReviewResultItem {
+		const reviewResulttArr = Object.keys(reviewResultObj) as ReviewResultItem[];
+		let maxKey: ReviewResultItem = reviewResulttArr[0];
 		let maxVal: number = reviewResultObj[reviewResulttArr[0]];
 		for (const key in reviewResultObj) {
 			if (reviewResultObj[key] > maxVal) {
-				maxKey = key as Weather | Time | Companion | Mood | string;
+				maxKey = key as ReviewResultItem;
 				maxVal = reviewResultObj[key];
 			}
 		}

--- a/apps/api-server/src/modules/drinks-evaluation/drinks-evaluation.service.ts
+++ b/apps/api-server/src/modules/drinks-evaluation/drinks-evaluation.service.ts
@@ -84,16 +84,18 @@ export class DrinksEvaluationService {
 	private findTopTastes(reviewResultObject: any) {
 		let reviewNum = 0;
 		let tastes = [];
-		for (const key in reviewResultObject) {
-			reviewNum += reviewResultObject[key];
-			if (reviewResultObject[key] > 0)
+
+		Object.entries(reviewResultObject).forEach(([taste_name, percent]) => {
+			reviewNum += percent as number;
+			if (percent > 0)
 				tastes.push(
 					new DrinksEvaluationTasteDto({
-						taste_name: key,
-						percent: reviewResultObject[key],
+						taste_name,
+						percent,
 					}),
 				);
-		}
+		});
+
 		tastes = tastes.sort((a, b) => b.percent - a.percent);
 		tastes = tastes.slice(0, 3);
 		tastes.map((element) => {
@@ -104,13 +106,10 @@ export class DrinksEvaluationService {
 	}
 
 	private findTopPairings(reviewResultObject: any, pairings: any): any {
-		let sortedPairingResult = [];
-		for (const key in reviewResultObject) {
-			if (reviewResultObject[key] > 0) sortedPairingResult.push([key, reviewResultObject[key]]);
-		}
+		let sortedPairingResult = Object.entries(reviewResultObject).filter(([pairing_name, value]) => value > 0);
 
 		sortedPairingResult.sort((a, b) => {
-			return b[1] - a[1];
+			return (b[1] as number) - (a[1] as number);
 		});
 		sortedPairingResult = sortedPairingResult.slice(0, 3);
 		for (const item of sortedPairingResult) {

--- a/apps/api-server/src/modules/drinks-evaluation/drinks-evaluation.service.ts
+++ b/apps/api-server/src/modules/drinks-evaluation/drinks-evaluation.service.ts
@@ -95,7 +95,7 @@ export class DrinksEvaluationService {
 				);
 		}
 		tastes = tastes.sort((a, b) => b.percent - a.percent);
-		tastes = tastes.slice(3);
+		tastes = tastes.slice(0, 3);
 		tastes.map((element) => {
 			element.percent = String(Math.floor((element.percent / reviewNum) * 100)) + '%';
 			return element;
@@ -112,7 +112,7 @@ export class DrinksEvaluationService {
 		sortedPairingResult.sort((a, b) => {
 			return b[1] - a[1];
 		});
-		sortedPairingResult = sortedPairingResult.slice(3);
+		sortedPairingResult = sortedPairingResult.slice(0, 3);
 		for (const item of sortedPairingResult) {
 			pairings.push(item[0]);
 		}

--- a/apps/api-server/src/modules/drinks-evaluation/dto/drinks-evaluation-bitter.dto.ts
+++ b/apps/api-server/src/modules/drinks-evaluation/dto/drinks-evaluation-bitter.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DrinksEvaluationBitterDto {
+	@ApiProperty({
+		example: 1,
+		description: '달아요(Sweet)으로 답한 리뷰 개수',
+	})
+	Sweet: number;
+
+	@ApiProperty({
+		example: 1,
+		description: '써요(Bitter)으로 답한 리뷰 개수',
+	})
+	Bitter: number;
+
+	constructor() {
+		this.Sweet = 0;
+		this.Bitter = 0;
+	}
+}

--- a/apps/api-server/src/modules/drinks-evaluation/dto/drinks-evaluation-burning.dto.ts
+++ b/apps/api-server/src/modules/drinks-evaluation/dto/drinks-evaluation-burning.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DrinksEvaluationBurningDto {
+	@ApiProperty({
+		example: 1,
+		description: '부드러운 목넘김(Smooth)으로 답한 리뷰 개수',
+	})
+	Smooth: number;
+
+	@ApiProperty({
+		example: 1,
+		description: '화끈거리는 목넘김(Burning)으로 답한 리뷰 개수',
+	})
+	Burning: number;
+
+	constructor() {
+		this.Smooth = 0;
+		this.Burning = 0;
+	}
+}

--- a/apps/api-server/src/modules/drinks-evaluation/dto/drinks-evaluation-response.dto.ts
+++ b/apps/api-server/src/modules/drinks-evaluation/dto/drinks-evaluation-response.dto.ts
@@ -1,0 +1,91 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Companion, Mood, Pairing, Time, Weather } from '@src/types/reviews.types';
+import { DrinksEvaluationBitterDto } from './drinks-evaluation-bitter.dto';
+import { DrinksEvaluationBurningDto } from './drinks-evaluation-burning.dto';
+import { DrinksEvaluationStrongDto } from './drinks-evaluation-strong.dto';
+import { DrinksEvaluationTasteDto } from './drinks-evaluation-taste.dto';
+import { DrinksEvaluationHeavyDto } from './drinks-evalutaion-heavy.dto';
+
+export class DrinksEvaluationReseponseDto {
+	@ApiProperty({
+		enum: Weather,
+		example: Weather.Rainy,
+		description: '가장 많이 답한 이 술을 마셨을 때의 날씨',
+	})
+	weather: Weather;
+
+	@ApiProperty({
+		enum: Time,
+		example: Time.Noon,
+		description: '가장 많이 답한 이 술을 마셨을 때의 시간',
+	})
+	time: Time;
+
+	@ApiProperty({
+		enum: Companion,
+		example: Companion.Alone,
+		description: '가장 많이 답한 이 술을 같이 마신 사람 유형',
+	})
+	companion: Companion;
+
+	@ApiProperty({
+		enum: Mood,
+		example: Mood.Funny,
+		description: '가장 많이 답한 이 술을 마셨을 때의 분위기',
+	})
+	mood: Mood;
+
+	@ApiProperty({
+		example: '1차',
+		description: '가장 많이 답한 이 술을 마셨을 때의 spot (1차, 2차, 3차) (리뷰가 없다면 빈 스트링)',
+	})
+	spot: string;
+
+	@ApiProperty({
+		description: '가벼워요(Light)/무거워요(Heavy) 각각의 리뷰 개수',
+	})
+	is_heavy: DrinksEvaluationHeavyDto;
+
+	@ApiProperty({
+		description: '달아요(Sweet)/써요(Bitter) 각각의 리뷰 개수',
+	})
+	is_bitter: DrinksEvaluationBitterDto;
+
+	@ApiProperty({
+		description: '은은한 술맛(Mild)/찐한 술맛(Strong) 각각의 리뷰 개수',
+	})
+	is_strong: DrinksEvaluationStrongDto;
+
+	@ApiProperty({
+		description: '부드러운 목넘김(Smooth)/화끈거리는 목넘김(Burning) 각각의 리뷰 개수',
+	})
+	is_burning: DrinksEvaluationBurningDto;
+
+	@ApiProperty({
+		description: '가장 많이 답한 이 술의 느낌들과 각 비율 (최대 3가지)',
+	})
+	taste: DrinksEvaluationTasteDto[];
+
+	@ApiProperty({
+		enum: [Pairing],
+		example: [Pairing.Grilled, Pairing.Fried],
+		description: '가장 많이 답한 곁들인 안주의 종류 (최대 3가지) (리뷰가 없다면 빈 배열)',
+	})
+	pairing: Pairing[];
+
+	constructor() {
+		this.weather = Weather.Rainy;
+		this.time = Time.Noon;
+		this.companion = Companion.Alone;
+		this.mood = Mood.Funny;
+		this.spot = '';
+
+		this.is_heavy = new DrinksEvaluationHeavyDto();
+		this.is_bitter = new DrinksEvaluationBitterDto();
+		this.is_strong = new DrinksEvaluationStrongDto();
+		this.is_burning = new DrinksEvaluationBurningDto();
+
+		this.taste = [];
+		this.pairing = [];
+	}
+}

--- a/apps/api-server/src/modules/drinks-evaluation/dto/drinks-evaluation-response.dto.ts
+++ b/apps/api-server/src/modules/drinks-evaluation/dto/drinks-evaluation-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Companion, Mood, Pairing, Time, Weather } from '@src/types/reviews.types';
+import { Companion, Mood, Pairing, Spot, Time, Weather } from '@src/types/reviews.types';
 import { DrinksEvaluationBitterDto } from './drinks-evaluation-bitter.dto';
 import { DrinksEvaluationBurningDto } from './drinks-evaluation-burning.dto';
 import { DrinksEvaluationStrongDto } from './drinks-evaluation-strong.dto';
@@ -36,10 +36,10 @@ export class DrinksEvaluationReseponseDto {
 	mood: Mood;
 
 	@ApiProperty({
-		example: '1차',
-		description: '가장 많이 답한 이 술을 마셨을 때의 spot (1차, 2차, 3차) (리뷰가 없다면 빈 스트링)',
+		example: '1',
+		description: '가장 많이 답한 이 술을 마셨을 때의 spot (1,2,3) (리뷰가 없다면 빈 스트링)',
 	})
-	spot: string;
+	spot: Spot | '';
 
 	@ApiProperty({
 		description: '가벼워요(Light)/무거워요(Heavy) 각각의 리뷰 개수',

--- a/apps/api-server/src/modules/drinks-evaluation/dto/drinks-evaluation-strong.dto.ts
+++ b/apps/api-server/src/modules/drinks-evaluation/dto/drinks-evaluation-strong.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DrinksEvaluationStrongDto {
+	@ApiProperty({
+		example: 1,
+		description: '은은한 술맛(Mild)으로 답한 리뷰 개수',
+	})
+	Mild: number;
+
+	@ApiProperty({
+		example: 1,
+		description: '찐한 술맛(Strong)으로 답한 리뷰 개수',
+	})
+	Strong: number;
+
+	constructor() {
+		this.Mild = 0;
+		this.Strong = 0;
+	}
+}

--- a/apps/api-server/src/modules/drinks-evaluation/dto/drinks-evaluation-taste.dto.ts
+++ b/apps/api-server/src/modules/drinks-evaluation/dto/drinks-evaluation-taste.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Taste } from '@src/types/reviews.types';
+
+export class DrinksEvaluationTasteDto {
+	@ApiProperty({
+		enum: Taste,
+		example: Taste.Fruity,
+		description: '술의 느낌',
+	})
+	taste_name: Taste;
+
+	@ApiProperty({
+		example: '20%',
+		description: '해당 느낌이라 답한 리뷰들의 비율',
+	})
+	percent: string | number;
+
+	constructor(tasteObj) {
+		this.taste_name = tasteObj.taste_name;
+		this.percent = tasteObj.percent;
+	}
+}

--- a/apps/api-server/src/modules/drinks-evaluation/dto/drinks-evalutaion-heavy.dto.ts
+++ b/apps/api-server/src/modules/drinks-evaluation/dto/drinks-evalutaion-heavy.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DrinksEvaluationHeavyDto {
+	@ApiProperty({
+		example: 1,
+		description: '가벼워요(Light)으로 답한 리뷰 개수',
+	})
+	Light: number;
+
+	@ApiProperty({
+		example: 1,
+		description: '무거워요(Heavy)으로 답한 리뷰 개수',
+	})
+	Heavy: number;
+
+	constructor() {
+		this.Light = 0;
+		this.Heavy = 0;
+	}
+}

--- a/apps/api-server/src/modules/drinks/dto/drink.constants.ts
+++ b/apps/api-server/src/modules/drinks/dto/drink.constants.ts
@@ -1,4 +1,5 @@
 export const DEFAULT_DRINK_REVIEW_RESULT = `{
+		"has_review" : false,
 		"weather": {
 			"Rainy": 0,
 			"Snowy": 0, 

--- a/apps/api-server/src/modules/drinks/dto/drink.constants.ts
+++ b/apps/api-server/src/modules/drinks/dto/drink.constants.ts
@@ -1,0 +1,88 @@
+export const DEFAULT_DRINK_REVIEW_RESULT = `{
+		"weather": {
+			"Rainy": 0,
+			"Snowy": 0, 
+			"Sunny": 0, 
+			"Cloudy": 0
+		},
+		"time": {
+			"Evening": 0, 
+			"Noon": 0, 
+			"Midnight": 0, 
+			"Dawn": 0
+		}, 
+		"companion": {
+			"Alone": 0, 
+			"Friends": 0, 
+			"Lover":0,
+			"Gather":0
+		},
+		"mood": {
+			"Funny" : 0,
+			"Serious" : 0,
+			"Romantic" : 0,
+			"Crazy" : 0,
+			"Gloomy" : 0,
+			"Celebratory" : 0,
+			"Delight" : 0,
+			"Enjoy" : 0
+		},
+		"spot":{
+			"1":0,
+			"2":0,
+			"3":0
+		},
+		"is_heavy": {
+			"1":0,
+			"2":0,
+			"3":0,
+			"4":0,
+			"5":0,
+			"6":0
+		},
+		"is_bitter": {
+			"1":0,
+			"2":0,
+			"3":0,
+			"4":0,
+			"5":0,
+			"6":0
+		},
+		"is_strong": {
+			"1":0,
+			"2":0,
+			"3":0,
+			"4":0,
+			"5":0,
+			"6":0
+		},
+		"is_burning": {
+			"1":0,
+			"2":0,
+			"3":0,
+			"4":0,
+			"5":0,
+			"6":0
+		},
+		"taste": {
+			"Fruity" : 0,
+			"Woody" : 0,
+			"Noroong" : 0,
+			"Creamy" : 0,
+			"Earthy" : 0,
+			"Flower" : 0,
+			"Austere" : 0,
+			"Chilli" : 0,
+			"Unknown":0
+		}, 
+		"pairing": {
+			"Grilled" : 0,
+			"Fried" : 0,
+			"Cheeze" : 0,
+			"Salad" : 0,
+			"Fruits" : 0,
+			"Soup" : 0,
+			"AppetizersSnacks" : 0,
+			"Pasta" : 0
+		}
+	}`;

--- a/apps/api-server/src/modules/reviews/reviews.service.ts
+++ b/apps/api-server/src/modules/reviews/reviews.service.ts
@@ -37,14 +37,15 @@ export class ReviewsService {
 				.getRawOne();
 
 			const reviewResult = reviewResultRow.review_result;
-
+			if (!reviewResult.has_review) reviewResult.has_review = true;
 			for (const key in createReviewDto) {
-				if (reviewResult.hasOwnProperty(key) && key !== 'pairing') {
-					reviewResult[key][createReviewDto[key]] += 1;
-				} else if (reviewResult.hasOwnProperty(key) && key === 'pairing') {
+				if (!reviewResult.hasOwnProperty(key)) continue;
+				else if (key === 'pairing') {
 					createReviewDto[key].forEach((value, index) => {
 						reviewResult[key][value] += 1;
 					});
+				} else {
+					reviewResult[key][createReviewDto[key]] += 1;
 				}
 			}
 

--- a/apps/api-server/src/modules/reviews/reviews.service.ts
+++ b/apps/api-server/src/modules/reviews/reviews.service.ts
@@ -38,14 +38,15 @@ export class ReviewsService {
 
 			const reviewResult = drink.review_result;
 			if (!reviewResult.has_review) reviewResult.has_review = true;
-			for (const key in createReviewDto) {
-				if (!reviewResult.hasOwnProperty(key)) continue;
-				else if (key === 'pairing') {
-					createReviewDto[key].forEach((value, index) => {
+
+			const { place, ...reviewKeys } = createReviewDto;
+			for (const key in reviewKeys) {
+				if (key !== 'pairing') {
+					reviewResult[key][createReviewDto[key]] += 1;
+				} else {
+					createReviewDto[key].forEach((value) => {
 						reviewResult[key][value] += 1;
 					});
-				} else {
-					reviewResult[key][createReviewDto[key]] += 1;
 				}
 			}
 

--- a/apps/api-server/src/modules/reviews/reviews.service.ts
+++ b/apps/api-server/src/modules/reviews/reviews.service.ts
@@ -3,13 +3,19 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { Repository } from 'typeorm';
 
+import { Drink } from '@src/entities/drinks.entity';
 import { Review } from '@src/entities/reviews.entity';
 import { CreateReviewDto } from './dto/create-review.dto';
 import { ReviewCardResponseDto } from './dto/review-card-response.dto';
 
 @Injectable()
 export class ReviewsService {
-	constructor(@InjectRepository(Review) private readonly reviewRepository: Repository<Review>) {}
+	constructor(
+		@InjectRepository(Review)
+		private readonly reviewRepository: Repository<Review>,
+		@InjectRepository(Drink)
+		private readonly drinkRepository: Repository<Drink>,
+	) {}
 
 	async createReview(userId: number, drinkId: number, createReviewDto: CreateReviewDto): Promise<number> {
 		try {
@@ -19,6 +25,32 @@ export class ReviewsService {
 				reviewed_drink_id: drinkId,
 			});
 			const result = await this.reviewRepository.save(review);
+
+			const reviewResultRow = await this.drinkRepository
+				.createQueryBuilder('drink')
+				.select(`(drink.review_result)::JSONB AS review_result`)
+				.where('drink.id = :id', { id: drinkId })
+				.getRawOne();
+
+			const reviewResult = reviewResultRow.review_result;
+
+			for (const key in createReviewDto) {
+				if (reviewResult.hasOwnProperty(key) && key !== 'pairing') {
+					reviewResult[key][createReviewDto[key]] += 1;
+				} else if (reviewResult.hasOwnProperty(key) && key === 'pairing') {
+					createReviewDto[key].forEach((value, index) => {
+						reviewResult[key][value] += 1;
+					});
+				}
+			}
+
+			await this.drinkRepository
+				.createQueryBuilder('drink')
+				.update(Drink)
+				.set({ review_result: reviewResult })
+				.where('drink.id = :id', { id: drinkId })
+				.execute();
+
 			return result.id;
 		} catch (error) {
 			throw new InternalServerErrorException(error.message, error);

--- a/apps/api-server/src/modules/reviews/reviews.service.ts
+++ b/apps/api-server/src/modules/reviews/reviews.service.ts
@@ -30,13 +30,13 @@ export class ReviewsService {
 			});
 			const result = await this.reviewRepository.save(review);
 
-			const reviewResultRow = await this.drinkRepository
+			const drink = await this.drinkRepository
 				.createQueryBuilder('drink')
 				.select(`(drink.review_result)::JSONB AS review_result`)
 				.where('drink.id = :id', { id: drinkId })
 				.getRawOne();
 
-			const reviewResult = reviewResultRow.review_result;
+			const reviewResult = drink.review_result;
 			if (!reviewResult.has_review) reviewResult.has_review = true;
 			for (const key in createReviewDto) {
 				if (!reviewResult.hasOwnProperty(key)) continue;

--- a/apps/api-server/src/types/reviews.types.ts
+++ b/apps/api-server/src/types/reviews.types.ts
@@ -30,6 +30,10 @@ export enum Mood { // 혼자서든 그 외든 '어떤 분위기로 마셨나요'
 	Enjoy = 'Enjoy',
 }
 
+export type Spot = '1' | '2' | '3';
+
+export type ReviewResultItem = Weather | Time | Companion | Mood | Spot;
+
 export enum Taste {
 	Fruity = 'Fruity', // 상큼달달한 과일
 	Woody = 'Woody', // 묵직한 나무

--- a/apps/api-server/test/mock/drinks-evaluation.mock.ts
+++ b/apps/api-server/test/mock/drinks-evaluation.mock.ts
@@ -1,0 +1,96 @@
+export const mockDrinksEvaluation = {
+	weather: {
+		Rainy: 2,
+		Snowy: 1,
+		Sunny: 0,
+		Cloudy: 0,
+	},
+	time: {
+		Evening: 2,
+		Noon: 1,
+		Midnight: 0,
+		Dawn: 0,
+	},
+	companion: {
+		Alone: 2,
+		Friends: 1,
+		Lover: 0,
+		Gather: 0,
+	},
+	mood: {
+		Funny: 2,
+		Serious: 1,
+		Romantic: 0,
+		Crazy: 0,
+		Gloomy: 0,
+		Celebratory: 0,
+		Delight: 0,
+		Enjoy: 0,
+	},
+	spot: {
+		'1': 2,
+		'2': 1,
+		'3': 0,
+	},
+	is_heavy: {
+		'1': 1,
+		'2': 0,
+		'3': 0,
+		'4': 1,
+		'5': 0,
+		'6': 0,
+	},
+	is_bitter: {
+		'1': 1,
+		'2': 0,
+		'3': 0,
+		'4': 1,
+		'5': 0,
+		'6': 0,
+	},
+	is_strong: {
+		'1': 1,
+		'2': 0,
+		'3': 0,
+		'4': 1,
+		'5': 0,
+		'6': 0,
+	},
+	is_burning: {
+		'1': 1,
+		'2': 0,
+		'3': 0,
+		'4': 1,
+		'5': 0,
+		'6': 0,
+	},
+	taste: {
+		Fruity: 2,
+		Woody: 1,
+		Noroong: 0,
+		Creamy: 0,
+		Earthy: 0,
+		Flower: 0,
+		Austere: 0,
+		Chilli: 0,
+		Unknown: 0,
+	},
+	pairing: {
+		Grilled: 2,
+		Fried: 1,
+		Cheeze: 0,
+		Salad: 0,
+		Fruits: 0,
+		Soup: 0,
+		AppetizersSnacks: 0,
+		Pasta: 0,
+	},
+};
+
+export class MockDrinksEvaluationRepository {
+	save = jest.fn().mockResolvedValue(mockDrinksEvaluation);
+
+	async find() {
+		return mockDrinksEvaluation;
+	}
+}


### PR DESCRIPTION
### 술 리뷰 평가 api
- 해당 술에 등록된 리뷰 데이터를 통계내어 술에 대한 전체적인 평가를 반환하는 api 입니다.
- 개별적인 조건들에 따라 db 접근을 한다면 10번 이상의 db접근이 이루어지는데, 이러한 성능저하를 고려하여 다음과 같은 방식을 사용했습니다.

### Drink table에 'review_result' 속성 추가
- jsonb 타입의 review_result 속성을 추가하여, 매번 술에 대한 리뷰가 생성될 때마다 이 jsonb에 리뷰 데이터를 count 시킵니다.
- 예시 : {
  "mood": {
    "Crazy": 5,
    "Enjoy": 0,
    "Funny": 2,
    "Gloomy": 1,
    "Delight": 1,
    "Serious": 2,
    "Romantic": 8,
    "Celebratory": 10
  },...}

### GET /drinks-evaluation
- 요청이 오면 Drink의 review_result 값을 가져와 통계를 냅니다.
  - 날씨/시간/누구랑/무드/스팟 : 가장 많이 답한 값 추출
  - 라이트/스위트/마일드/스무스 : 모두 두 속성으로 분리되는데, 각각의 속성의 리뷰 개수를 추출 (light: light(8개), heavy(10개..)
  - taste : 상위 3개 데이터 추출 (최대 3개)
  - pairing : 상위 3개 데이터와 각 데이터의 퍼센트 추출 (최대 3개)

### 요청드리고 싶은 부분
- 계속해서 테스트를 진행할 것이지만, 제가 못찾는 부분(오류)들이 있을수도 있어서.. 시간 되실때마다 한번씩 테스트해주시면 감사합니다!!