### PR TITLE
Worldcup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # compiled output
 **/dist
 **/node_modules
+*/.pnpm-store/*
 
 # Logs
 logs

--- a/apps/api-server/src/database/database.config.ts
+++ b/apps/api-server/src/database/database.config.ts
@@ -7,6 +7,7 @@ import { User } from '@src/entities/users.entity';
 import { UsersProfile } from '@src/entities/users-profile.entity';
 import { Drink } from '@src/entities/drinks.entity';
 import { Worldcup } from '@src/entities/worldcup.entity';
+import { WorldcupResult } from '@src/entities/worldcup-result.entity';
 import { Review } from '@src/entities/reviews.entity';
 
 const dbConfig = databaseConfig().databaseConfig;
@@ -19,7 +20,7 @@ const config = {
 	username: dbConfig.username,
 	password: `${dbConfig.password}`,
 	database: dbConfig.dbname,
-	entities: [UsersProfile, User, DrinksCategory, Drink, Worldcup, Review],
+	entities: [UsersProfile, User, DrinksCategory, Drink, Worldcup, WorldcupResult, Review],
 	seeds: [
 		'apps/api-server/src/database/seeds/users-profile.seed.ts',
 		'apps/api-server/src/database/seeds/users.seed.ts',

--- a/apps/api-server/src/database/database.config.ts
+++ b/apps/api-server/src/database/database.config.ts
@@ -8,6 +8,7 @@ import { UsersProfile } from '@src/entities/users-profile.entity';
 import { Drink } from '@src/entities/drinks.entity';
 import { Worldcup } from '@src/entities/worldcup.entity';
 import { WorldcupResult } from '@src/entities/worldcup-result.entity';
+import { WorldcupResultItem } from '@src/entities/worldcup-result-item.entity';
 import { Review } from '@src/entities/reviews.entity';
 
 const dbConfig = databaseConfig().databaseConfig;
@@ -20,7 +21,7 @@ const config = {
 	username: dbConfig.username,
 	password: `${dbConfig.password}`,
 	database: dbConfig.dbname,
-	entities: [UsersProfile, User, DrinksCategory, Drink, Worldcup, WorldcupResult, Review],
+	entities: [UsersProfile, User, DrinksCategory, Drink, Worldcup, WorldcupResult, WorldcupResultItem, Review],
 	seeds: [
 		'apps/api-server/src/database/seeds/users-profile.seed.ts',
 		'apps/api-server/src/database/seeds/users.seed.ts',

--- a/apps/api-server/src/entities/drinks.entity.ts
+++ b/apps/api-server/src/entities/drinks.entity.ts
@@ -6,6 +6,7 @@ import { DrinksCategory } from './drinks-category.entity';
 import { Review } from './reviews.entity';
 import { CommonEntity } from './common.entity';
 import { IsNotEmpty, IsNumber } from 'class-validator';
+import { WorldcupResult } from './worldcup-result.entity';
 
 @Entity()
 export class Drink extends CommonEntity {
@@ -72,4 +73,7 @@ export class Drink extends CommonEntity {
 		cascade: true, // user를 통해 review가 추가, 수정, 삭제되고 사용자가 저장되면 추가된 review도 저장된다.
 	})
 	reviews: Review[];
+
+	@OneToMany(() => WorldcupResult, (worldcupResult) => worldcupResult.drink)
+	worldcupResults: WorldcupResult[];
 }

--- a/apps/api-server/src/entities/drinks.entity.ts
+++ b/apps/api-server/src/entities/drinks.entity.ts
@@ -7,6 +7,7 @@ import { Review } from './reviews.entity';
 import { CommonEntity } from './common.entity';
 import { IsNotEmpty, IsNumber } from 'class-validator';
 import { WorldcupResult } from './worldcup-result.entity';
+import { WorldcupResultItem } from './worldcup-result-item.entity';
 
 @Entity()
 export class Drink extends CommonEntity {
@@ -74,6 +75,6 @@ export class Drink extends CommonEntity {
 	})
 	reviews: Review[];
 
-	@OneToMany(() => WorldcupResult, (worldcupResult) => worldcupResult.drink)
-	worldcupResults: WorldcupResult[];
+	@OneToMany(() => WorldcupResultItem, (worldcupResultItem) => worldcupResultItem.drink)
+	worldcupResultItems: WorldcupResultItem[];
 }

--- a/apps/api-server/src/entities/users.entity.ts
+++ b/apps/api-server/src/entities/users.entity.ts
@@ -6,6 +6,7 @@ import { UserType } from '@src/types/users.types';
 import { CommonEntity } from './common.entity';
 import { Review } from './reviews.entity';
 import { UsersProfile } from './users-profile.entity';
+import { WorldcupResult } from './worldcup-result.entity';
 
 @Entity()
 export class User extends CommonEntity {
@@ -45,4 +46,6 @@ export class User extends CommonEntity {
 
 	@ManyToOne(() => UsersProfile, (userProfile) => userProfile.users, { nullable: false })
 	profile: UsersProfile;
+
+	worldcupResults: WorldcupResult[];
 }

--- a/apps/api-server/src/entities/worldcup-result-item.entity.ts
+++ b/apps/api-server/src/entities/worldcup-result-item.entity.ts
@@ -26,6 +26,6 @@ export class WorldcupResultItem {
 	worldcupResultId: number;
 
 	@JoinColumn({ name: 'worldcup_result_id' })
-	@ManyToOne(() => WorldcupResult, (worldcupResult) => worldcupResult.items)
+	@ManyToOne(() => WorldcupResult, (worldcupResult) => worldcupResult.items, { onDelete: 'CASCADE' })
 	worldcupResult: WorldcupResult;
 }

--- a/apps/api-server/src/entities/worldcup-result-item.entity.ts
+++ b/apps/api-server/src/entities/worldcup-result-item.entity.ts
@@ -1,0 +1,31 @@
+import { IsNumber } from 'class-validator';
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn, RelationId } from 'typeorm';
+
+import { Drink } from './drinks.entity';
+import { WorldcupResult } from './worldcup-result.entity';
+
+@Entity()
+export class WorldcupResultItem {
+	@PrimaryGeneratedColumn()
+	id: number;
+
+	@IsNumber()
+	@Column({ name: 'rank_level', nullable: false, comment: '0: 1등, 1: 2등, 2: 3~4등, 3: 5~8등...' })
+	rankLevel!: number;
+
+	@IsNumber()
+	@Column({ nullable: false })
+	drinkId!: number;
+
+	@JoinColumn({ name: 'drink_id' })
+	@ManyToOne(() => Drink, (drink) => drink.worldcupResultItems)
+	drink: Drink;
+
+	@IsNumber()
+	@Column({ name: 'worldcup_result_id' })
+	worldcupResultId: number;
+
+	@JoinColumn({ name: 'worldcup_result_id' })
+	@ManyToOne(() => WorldcupResult, (worldcupResult) => worldcupResult.items)
+	worldcupResult: WorldcupResult;
+}

--- a/apps/api-server/src/entities/worldcup-result.entity.ts
+++ b/apps/api-server/src/entities/worldcup-result.entity.ts
@@ -5,32 +5,25 @@ import { CommonEntity } from './common.entity';
 import { Worldcup } from './worldcup.entity';
 import { Drink } from './drinks.entity';
 import { User } from './users.entity';
+import { WorldcupResultItem } from './worldcup-result-item.entity';
 
 @Entity()
 export class WorldcupResult extends CommonEntity {
-	@Column({ name: 'rank_level', nullable: false, comment: '0: 1등, 1: 2등, 2: 3~4등, 3: 5~8등...' })
-	rankLevel!: number;
-
 	@IsNumber()
 	@Column({ nullable: true })
 	userId?: number;
-
-	@IsNumber()
-	@Column({ nullable: false })
-	worldcupId!: number;
-
-	@Column({ nullable: false })
-	drinkId!: number;
 
 	@JoinColumn({ name: 'user_id' })
 	@ManyToOne(() => User)
 	user: User;
 
+	@IsNumber()
+	@Column({ nullable: false })
+	worldcupId!: number;
+
 	@JoinColumn({ name: 'worldcup_id' })
 	@ManyToOne(() => Worldcup, { onDelete: 'RESTRICT' })
 	worldcup: Worldcup;
 
-	@JoinColumn({ name: 'drink_id' })
-	@ManyToOne(() => Drink, (drink) => drink.worldcupResults)
-	drink: Drink;
+	items: WorldcupResultItem[];
 }

--- a/apps/api-server/src/entities/worldcup-result.entity.ts
+++ b/apps/api-server/src/entities/worldcup-result.entity.ts
@@ -1,0 +1,36 @@
+import { IsNumber } from 'class-validator';
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany, RelationId } from 'typeorm';
+
+import { CommonEntity } from './common.entity';
+import { Worldcup } from './worldcup.entity';
+import { Drink } from './drinks.entity';
+import { User } from './users.entity';
+
+@Entity()
+export class WorldcupResult extends CommonEntity {
+	@Column({ name: 'rank_level', nullable: false, comment: '0: 1등, 1: 2등, 2: 3~4등, 3: 5~8등...' })
+	rankLevel!: number;
+
+	@IsNumber()
+	@Column({ nullable: true })
+	userId?: number;
+
+	@IsNumber()
+	@Column({ nullable: false })
+	worldcupId!: number;
+
+	@Column({ nullable: false })
+	drinkId!: number;
+
+	@JoinColumn({ name: 'user_id' })
+	@ManyToOne(() => User)
+	user: User;
+
+	@JoinColumn({ name: 'worldcup_id' })
+	@ManyToOne(() => Worldcup, { onDelete: 'RESTRICT' })
+	worldcup: Worldcup;
+
+	@JoinColumn({ name: 'drink_id' })
+	@ManyToOne(() => Drink, (drink) => drink.worldcupResults)
+	drink: Drink;
+}

--- a/apps/api-server/src/entities/worldcup.entity.ts
+++ b/apps/api-server/src/entities/worldcup.entity.ts
@@ -3,6 +3,7 @@ import { Column, Entity } from 'typeorm';
 
 import { WorldcupRoundDto } from '@src/modules/worldcup/dto/worldcup.dto';
 import { CommonEntity } from './common.entity';
+import { WorldcupResult } from './worldcup-result.entity';
 
 @Entity()
 export class Worldcup extends CommonEntity {
@@ -31,4 +32,6 @@ export class Worldcup extends CommonEntity {
 
 	@Column({ type: 'jsonb' })
 	round: WorldcupRoundDto[];
+
+	results: WorldcupResult[];
 }

--- a/apps/api-server/src/modules/auth/guards/optional-jwt-auth.guard.ts
+++ b/apps/api-server/src/modules/auth/guards/optional-jwt-auth.guard.ts
@@ -1,0 +1,18 @@
+import { AuthGuard } from '@nestjs/passport';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { JsonWebTokenError } from 'jsonwebtoken';
+
+@Injectable()
+export class OptionalJwtAuthGuard extends AuthGuard('jwt') {
+	handleRequest(error, user) {
+		if (error) {
+			throw new UnauthorizedException(error);
+		}
+
+		if (!user) {
+			return null;
+		}
+
+		return user;
+	}
+}

--- a/apps/api-server/src/modules/drinks/drinks.module.ts
+++ b/apps/api-server/src/modules/drinks/drinks.module.ts
@@ -4,10 +4,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { DrinksService } from './drinks.service';
 import { DrinksController } from './drinks.controller';
 import { Drink } from '@src/entities/drinks.entity';
-import { WorldcupResult } from '@src/entities/worldcup-result.entity';
+import { WorldcupResultItem } from '@src/entities/worldcup-result-item.entity';
 
 @Module({
-	imports: [TypeOrmModule.forFeature([Drink, WorldcupResult])],
+	imports: [TypeOrmModule.forFeature([Drink, WorldcupResultItem])],
 	providers: [DrinksService],
 	controllers: [DrinksController],
 	exports: [DrinksService],

--- a/apps/api-server/src/modules/drinks/drinks.module.ts
+++ b/apps/api-server/src/modules/drinks/drinks.module.ts
@@ -4,10 +4,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { DrinksService } from './drinks.service';
 import { DrinksController } from './drinks.controller';
 import { Drink } from '@src/entities/drinks.entity';
+import { WorldcupResult } from '@src/entities/worldcup-result.entity';
 
 @Module({
-	imports: [TypeOrmModule.forFeature([Drink])],
+	imports: [TypeOrmModule.forFeature([Drink, WorldcupResult])],
 	providers: [DrinksService],
 	controllers: [DrinksController],
+	exports: [DrinksService],
 })
 export class DrinksModule {}

--- a/apps/api-server/src/modules/drinks/drinks.service.ts
+++ b/apps/api-server/src/modules/drinks/drinks.service.ts
@@ -6,12 +6,13 @@ import { Repository } from 'typeorm';
 import { Drink } from '@src/entities/drinks.entity';
 import { CreateDrinkDto } from './dto/create-drink.dto';
 import { DrinkDto } from './dto/drink.dto';
+import { WorldcupResult } from '@src/entities/worldcup-result.entity';
 
 @Injectable()
 export class DrinksService {
 	constructor(
-		@InjectRepository(Drink)
-		private readonly drinkRepository: Repository<Drink>,
+		@InjectRepository(Drink) private readonly drinkRepository: Repository<Drink>,
+		@InjectRepository(WorldcupResult) private readonly worldcupResultRepository: Repository<WorldcupResult>,
 	) {}
 
 	// TODO
@@ -43,7 +44,11 @@ export class DrinksService {
 			if (!drink) {
 				throw new BadRequestException();
 			}
-			return drink;
+
+			const drinkDto = new DrinkDto(drink);
+			drinkDto.worldcupWinCount = await this.worldcupResultRepository.countBy({ drinkId: id, rankLevel: 0 });
+
+			return drinkDto;
 		} catch (error) {
 			throw new InternalServerErrorException(error.message, error);
 		}

--- a/apps/api-server/src/modules/drinks/drinks.service.ts
+++ b/apps/api-server/src/modules/drinks/drinks.service.ts
@@ -6,13 +6,14 @@ import { Repository } from 'typeorm';
 import { Drink } from '@src/entities/drinks.entity';
 import { CreateDrinkDto } from './dto/create-drink.dto';
 import { DrinkDto } from './dto/drink.dto';
-import { WorldcupResult } from '@src/entities/worldcup-result.entity';
+import { WorldcupResultItem } from '@src/entities/worldcup-result-item.entity';
 
 @Injectable()
 export class DrinksService {
 	constructor(
 		@InjectRepository(Drink) private readonly drinkRepository: Repository<Drink>,
-		@InjectRepository(WorldcupResult) private readonly worldcupResultRepository: Repository<WorldcupResult>,
+		@InjectRepository(WorldcupResultItem)
+		private readonly worldcupResultItemRepository: Repository<WorldcupResultItem>,
 	) {}
 
 	// TODO
@@ -46,7 +47,7 @@ export class DrinksService {
 			}
 
 			const drinkDto = new DrinkDto(drink);
-			drinkDto.worldcupWinCount = await this.worldcupResultRepository.countBy({ drinkId: id, rankLevel: 0 });
+			drinkDto.worldcupWinCount = await this.worldcupResultItemRepository.countBy({ drinkId: id, rankLevel: 0 });
 
 			return drinkDto;
 		} catch (error) {

--- a/apps/api-server/src/modules/drinks/dto/drink.dto.ts
+++ b/apps/api-server/src/modules/drinks/dto/drink.dto.ts
@@ -47,6 +47,10 @@ export class DrinkDto {
 	@IsEnum(Category)
 	category: Pick<DrinksCategory, 'name'>;
 
+	@ApiProperty({ description: '월드컵 우승 횟수' })
+	@IsNumber()
+	worldcupWinCount?: number;
+
 	constructor({ ...args }) {
 		this.id = args.id;
 		this.createdAt = args.createdAt;
@@ -58,5 +62,7 @@ export class DrinkDto {
 		this.origin = args.origin;
 		this.description = args.description;
 		this.category = args.category;
+
+		this.worldcupWinCount = args.worldcupWinCount;
 	}
 }

--- a/apps/api-server/src/modules/reviews/reviews.module.ts
+++ b/apps/api-server/src/modules/reviews/reviews.module.ts
@@ -7,11 +7,11 @@ import { ReviewsController } from './reviews.controller';
 import { Review } from '@src/entities/reviews.entity';
 import { User } from '@src/entities/users.entity';
 import { Drink } from '@src/entities/drinks.entity';
-import { DrinksService } from '../drinks/drinks.service';
+import { DrinksModule } from '../drinks/drinks.module';
 
 @Module({
-	imports: [TypeOrmModule.forFeature([Review, User, Drink])],
+	imports: [DrinksModule, TypeOrmModule.forFeature([Review, User, Drink])],
 	controllers: [ReviewsController],
-	providers: [ReviewsService, DrinksService],
+	providers: [ReviewsService],
 })
 export class ReviewsModule {}

--- a/apps/api-server/src/modules/worldcup/dto/submit-worldcup-request.dto.ts
+++ b/apps/api-server/src/modules/worldcup/dto/submit-worldcup-request.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SubmitWorldcupRequestDto {
+	@ApiProperty({
+		example: [2, 5, 1, 3, 6, 4, 8, 7],
+	})
+	drinkIds: number[];
+}

--- a/apps/api-server/src/modules/worldcup/dto/user-participated-worldcup-result-response.dto.ts
+++ b/apps/api-server/src/modules/worldcup/dto/user-participated-worldcup-result-response.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { WorldcupReseponseDto } from './worldcup-response.dto';
+import { WorldcupConditionDto, WorldcupRoundDto } from './worldcup.dto';
+
+export class UserParticipatedWorldcupResultDto {
+	@ApiProperty({ description: '월드컵 id' })
+	id: number;
+
+	@ApiProperty({ description: '월드컵 데이터' })
+	worldcup: WorldcupReseponseDto;
+
+	@ApiProperty({ description: '해당 월드컵에서 1등했던 술' })
+	winnerDrinkId: number;
+
+	@ApiProperty({ description: '이 월드컵에 참여한 사람' })
+	participantCount: number;
+
+	constructor(worldcupResult) {
+		this.id = worldcupResult.id;
+		this.winnerDrinkId = worldcupResult.winnerDrinkId;
+
+		this.worldcup = new WorldcupReseponseDto({
+			id: worldcupResult.worldcup_id,
+			title: `${worldcupResult.worldcup_situation_content} 날 마시고 싶은 술은?`,
+			withWho: {
+				code: worldcupResult.worldcup_with_who_code,
+				content: worldcupResult.worldcup_with_who_content,
+				title: worldcupResult.worldcup_with_who_title,
+			},
+			situation: {
+				code: worldcupResult.worldcup_situation_code,
+				content: worldcupResult.worldcup_situation_content,
+				title: worldcupResult.worldcup_situation_title,
+			},
+			round: worldcupResult.worldcup_round,
+			participantCount: +worldcupResult.participant_count,
+		});
+	}
+}

--- a/apps/api-server/src/modules/worldcup/dto/user-participated-worldcup-result-response.dto.ts
+++ b/apps/api-server/src/modules/worldcup/dto/user-participated-worldcup-result-response.dto.ts
@@ -22,16 +22,12 @@ export class UserParticipatedWorldcupResultDto {
 		this.worldcup = new WorldcupReseponseDto({
 			id: worldcupResult.worldcup_id,
 			title: `${worldcupResult.worldcup_situation_content} 날 마시고 싶은 술은?`,
-			withWho: {
-				code: worldcupResult.worldcup_with_who_code,
-				content: worldcupResult.worldcup_with_who_content,
-				title: worldcupResult.worldcup_with_who_title,
-			},
-			situation: {
-				code: worldcupResult.worldcup_situation_code,
-				content: worldcupResult.worldcup_situation_content,
-				title: worldcupResult.worldcup_situation_title,
-			},
+			withWhoCode: worldcupResult.worldcup_with_who_code,
+			withWhoContent: worldcupResult.worldcup_with_who_content,
+			withWhoTitle: worldcupResult.worldcup_with_who_title,
+			situationCode: worldcupResult.worldcup_situation_code,
+			situationContent: worldcupResult.worldcup_situation_content,
+			situationTitle: worldcupResult.worldcup_situation_title,
 			round: worldcupResult.worldcup_round,
 			participantCount: +worldcupResult.participant_count,
 		});

--- a/apps/api-server/src/modules/worldcup/dto/worldcup-response.dto.ts
+++ b/apps/api-server/src/modules/worldcup/dto/worldcup-response.dto.ts
@@ -17,6 +17,9 @@ export class WorldcupReseponseDto {
 	@ApiProperty({ description: '몇 강으로 진행할지', type: [WorldcupRoundDto] })
 	round: WorldcupRoundDto;
 
+	@ApiProperty({ description: '이 월드컵에 참여한 사람' })
+	participantCount?: number;
+
 	constructor(worldcup) {
 		this.id = worldcup.id;
 		this.title = `${worldcup.situationContent} 날 마시고 싶은 술은?`;
@@ -31,5 +34,6 @@ export class WorldcupReseponseDto {
 			title: worldcup.situationTitle,
 		};
 		this.round = worldcup.round;
+		this.participantCount = worldcup.participantCount;
 	}
 }

--- a/apps/api-server/src/modules/worldcup/dto/worldcup-response.dto.ts
+++ b/apps/api-server/src/modules/worldcup/dto/worldcup-response.dto.ts
@@ -5,6 +5,9 @@ export class WorldcupReseponseDto {
 	@ApiProperty({ description: '월드컵 id' })
 	id: number;
 
+	@ApiProperty({ description: '월드컵 제목' })
+	title: string;
+
 	@ApiProperty({ description: '월드컵 - 누구와 함께 술을 마시는지' })
 	withWho: WorldcupConditionDto;
 
@@ -16,6 +19,7 @@ export class WorldcupReseponseDto {
 
 	constructor(worldcup) {
 		this.id = worldcup.id;
+		this.title = `${worldcup.situationContent} 날 마시고 싶은 술은?`;
 		this.withWho = {
 			code: worldcup.withWhoCode,
 			content: worldcup.withWhoContent,

--- a/apps/api-server/src/modules/worldcup/dto/worldcup-with-participant-count-response.dto.ts
+++ b/apps/api-server/src/modules/worldcup/dto/worldcup-with-participant-count-response.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { WorldcupConditionDto, WorldcupRoundDto } from './worldcup.dto';
+
+export class WorldcupWithParticipantCountReseponseDto {
+	@ApiProperty({ description: '월드컵 id' })
+	id: number;
+
+	@ApiProperty({ description: '월드컵 제목' })
+	title: string;
+
+	@ApiProperty({ description: '월드컵 - 누구와 함께 술을 마시는지' })
+	withWho: WorldcupConditionDto;
+
+	@ApiProperty({ description: '월드컵 - 술을 마신 상황' })
+	situation: WorldcupConditionDto;
+
+	@ApiProperty({ description: '몇 강으로 진행할지', type: [WorldcupRoundDto] })
+	round: WorldcupRoundDto;
+
+	@ApiProperty({ description: '이 월드컵에 참여한 사람' })
+	participantCount: number;
+
+	constructor(worldcup) {
+		this.id = worldcup.id;
+		this.title = `${worldcup.situation_content} 날 마시고 싶은 술은?`;
+		this.withWho = {
+			code: worldcup.with_who_code,
+			content: worldcup.with_who_content,
+			title: worldcup.with_who_title,
+		};
+		this.situation = {
+			code: worldcup.situation_code,
+			content: worldcup.situation_content,
+			title: worldcup.situation_title,
+		};
+		this.round = worldcup.round;
+		this.participantCount = +worldcup.participant_count;
+	}
+}

--- a/apps/api-server/src/modules/worldcup/worldcup.controller.ts
+++ b/apps/api-server/src/modules/worldcup/worldcup.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Get, Param, Post, Query, UseGuards } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiCreatedResponse, ApiTags } from '@nestjs/swagger';
 import { AuthUser } from '@src/decorators/auth.decorator';
 import { User } from '@src/entities/users.entity';
 import { OptionalJwtAuthGuard } from '../auth/guards/optional-jwt-auth.guard';
@@ -34,9 +34,9 @@ export class WorldcupController {
 
 	@Post('/:id')
 	@UseGuards(OptionalJwtAuthGuard)
+	@ApiCreatedResponse({ description: '월드컵 결과 제출 성공' })
 	@ApiDocs.submitWoldcupResult('월드컵 결과 제출하기')
 	async submitWoldcupResult(@AuthUser() user: User, @Param('id') id: number, @Body('drinkIds') drinkIds: number[]) {
-		const worldcupResult = await this.worldcupService.submitWoldcupResult(id, drinkIds, user?.id);
-		return worldcupResult;
+		await this.worldcupService.submitWoldcupResult(id, drinkIds, user?.id);
 	}
 }

--- a/apps/api-server/src/modules/worldcup/worldcup.controller.ts
+++ b/apps/api-server/src/modules/worldcup/worldcup.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Get, Param, Post, Query, UseGuards } from '@nestjs/co
 import { ApiCreatedResponse, ApiTags } from '@nestjs/swagger';
 import { AuthUser } from '@src/decorators/auth.decorator';
 import { User } from '@src/entities/users.entity';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { OptionalJwtAuthGuard } from '../auth/guards/optional-jwt-auth.guard';
 import { ApiDocs } from './worldcup.docs';
 import { WorldcupService } from './worldcup.service';
@@ -22,7 +23,14 @@ export class WorldcupController {
 	@ApiDocs.getPopularWorldcup('현재 인기 있는 월드컵 조회')
 	async getPopularWorldcup() {
 		const worldcups = await this.worldcupService.getPopularWorldcup();
-		console.log(worldcups);
+		return worldcups;
+	}
+
+	@Get('/user-participated')
+	@UseGuards(JwtAuthGuard)
+	@ApiDocs.getParticipatedWorldcup('내가 참여한 월드컵')
+	async getParticipatedWorldcup(@AuthUser() user: User) {
+		const worldcups = await this.worldcupService.getParticipatedWorldcup(user.id);
 		return worldcups;
 	}
 

--- a/apps/api-server/src/modules/worldcup/worldcup.controller.ts
+++ b/apps/api-server/src/modules/worldcup/worldcup.controller.ts
@@ -1,12 +1,15 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
+import { AuthUser } from '@src/decorators/auth.decorator';
+import { User } from '@src/entities/users.entity';
+import { OptionalJwtAuthGuard } from '../auth/guards/optional-jwt-auth.guard';
 import { ApiDocs } from './worldcup.docs';
-import { WolrdCupService } from './worldcup.service';
+import { WorldcupService } from './worldcup.service';
 
 @Controller('worldcups')
 @ApiTags('월드컵')
 export class WorldcupController {
-	constructor(private readonly worldcupService: WolrdCupService) {}
+	constructor(private readonly worldcupService: WorldcupService) {}
 
 	@Get()
 	@ApiDocs.getWorldcups('전체 월드컵 조회')
@@ -16,9 +19,9 @@ export class WorldcupController {
 	}
 
 	@Get('/:id')
-	@ApiDocs.getWolrdcupById('월드컵 하나의 정보 조회')
-	async getWolrdcupById(@Param('id') id: number) {
-		const worldcup = await this.worldcupService.getWolrdcupById(id);
+	@ApiDocs.getWorldcupById('월드컵 하나의 정보 조회')
+	async getWorldcupById(@Param('id') id: number) {
+		const worldcup = await this.worldcupService.getWorldcupById(id);
 		return worldcup;
 	}
 
@@ -27,5 +30,12 @@ export class WorldcupController {
 	async getWorldcupItems(@Param('id') id: number, @Query('roundCount') roundCount: number) {
 		const worldcupItem = await this.worldcupService.getWorldcupItemById(id, roundCount);
 		return worldcupItem;
+	}
+
+	@Post('/:id')
+	@ApiDocs.submitWoldcupResult('월드컵 결과 제출하기')
+	async submitWoldcupResult(@AuthUser() user: User, @Param('id') id: number, @Body('drinkIds') drinkIds: number[]) {
+		const worldcupResult = await this.worldcupService.submitWoldcupResult(id, drinkIds, user?.id);
+		return worldcupResult;
 	}
 }

--- a/apps/api-server/src/modules/worldcup/worldcup.controller.ts
+++ b/apps/api-server/src/modules/worldcup/worldcup.controller.ts
@@ -33,6 +33,7 @@ export class WorldcupController {
 	}
 
 	@Post('/:id')
+	@UseGuards(OptionalJwtAuthGuard)
 	@ApiDocs.submitWoldcupResult('월드컵 결과 제출하기')
 	async submitWoldcupResult(@AuthUser() user: User, @Param('id') id: number, @Body('drinkIds') drinkIds: number[]) {
 		const worldcupResult = await this.worldcupService.submitWoldcupResult(id, drinkIds, user?.id);

--- a/apps/api-server/src/modules/worldcup/worldcup.controller.ts
+++ b/apps/api-server/src/modules/worldcup/worldcup.controller.ts
@@ -18,6 +18,14 @@ export class WorldcupController {
 		return worldcups;
 	}
 
+	@Get('/popular')
+	@ApiDocs.getPopularWorldcup('현재 인기 있는 월드컵 조회')
+	async getPopularWorldcup() {
+		const worldcups = await this.worldcupService.getPopularWorldcup();
+		console.log(worldcups);
+		return worldcups;
+	}
+
 	@Get('/:id')
 	@ApiDocs.getWorldcupById('월드컵 하나의 정보 조회')
 	async getWorldcupById(@Param('id') id: number) {

--- a/apps/api-server/src/modules/worldcup/worldcup.docs.ts
+++ b/apps/api-server/src/modules/worldcup/worldcup.docs.ts
@@ -21,6 +21,19 @@ export const ApiDocs: SwaggerMethodDoc<WorldcupController> = {
 			ApiBearerAuth('Authorization'),
 		);
 	},
+	getPopularWorldcup(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+			}),
+			ApiResponse({
+				status: 200,
+				description: '',
+				type: [WorldcupReseponseDto],
+			}),
+			ApiBearerAuth('Authorization'),
+		);
+	},
 	getWorldcupById(summary: string) {
 		return applyDecorators(
 			ApiOperation({

--- a/apps/api-server/src/modules/worldcup/worldcup.docs.ts
+++ b/apps/api-server/src/modules/worldcup/worldcup.docs.ts
@@ -2,6 +2,7 @@ import { applyDecorators } from '@nestjs/common';
 import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiQuery, ApiResponse } from '@nestjs/swagger';
 import { SwaggerMethodDoc } from '@src/swagger/swagger-method-doc-type';
 import { number } from 'joi';
+import { SubmitWorldcupRequestDto } from './dto/submit-worldcup-request.dto';
 import { WorldcupReseponseDto } from './dto/worldcup-response.dto';
 import { WorldcupController } from './worldcup.controller';
 
@@ -20,7 +21,7 @@ export const ApiDocs: SwaggerMethodDoc<WorldcupController> = {
 			ApiBearerAuth('Authorization'),
 		);
 	},
-	getWolrdcupById(summary: string) {
+	getWorldcupById(summary: string) {
 		return applyDecorators(
 			ApiOperation({
 				summary,
@@ -43,6 +44,28 @@ export const ApiDocs: SwaggerMethodDoc<WorldcupController> = {
 			ApiQuery({
 				name: 'roundCount',
 				type: 'number',
+			}),
+			ApiResponse({
+				status: 200,
+				description: '',
+				type: WorldcupReseponseDto,
+			}),
+			ApiBearerAuth('Authorization'),
+		);
+	},
+	submitWoldcupResult(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: '유저의 월드컵 결과 제출',
+			}),
+			ApiParam({
+				name: 'id',
+				required: true,
+				description: '월드컵 id',
+			}),
+			ApiBody({
+				type: SubmitWorldcupRequestDto,
 			}),
 			ApiResponse({
 				status: 200,

--- a/apps/api-server/src/modules/worldcup/worldcup.docs.ts
+++ b/apps/api-server/src/modules/worldcup/worldcup.docs.ts
@@ -3,7 +3,9 @@ import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiQuery, ApiResponse }
 import { SwaggerMethodDoc } from '@src/swagger/swagger-method-doc-type';
 import { number } from 'joi';
 import { SubmitWorldcupRequestDto } from './dto/submit-worldcup-request.dto';
+import { UserParticipatedWorldcupResultDto } from './dto/user-participated-worldcup-result-response.dto';
 import { WorldcupReseponseDto } from './dto/worldcup-response.dto';
+import { WorldcupWithParticipantCountReseponseDto } from './dto/worldcup-with-participant-count-response.dto';
 import { WorldcupController } from './worldcup.controller';
 
 export const ApiDocs: SwaggerMethodDoc<WorldcupController> = {
@@ -25,11 +27,12 @@ export const ApiDocs: SwaggerMethodDoc<WorldcupController> = {
 		return applyDecorators(
 			ApiOperation({
 				summary,
+				description: '인기있는 월드컵 조회',
 			}),
 			ApiResponse({
 				status: 200,
 				description: '',
-				type: [WorldcupReseponseDto],
+				type: [WorldcupWithParticipantCountReseponseDto],
 			}),
 			ApiBearerAuth('Authorization'),
 		);
@@ -43,7 +46,7 @@ export const ApiDocs: SwaggerMethodDoc<WorldcupController> = {
 			ApiResponse({
 				status: 200,
 				description: '',
-				type: [WorldcupReseponseDto],
+				type: [UserParticipatedWorldcupResultDto],
 			}),
 			ApiBearerAuth('Authorization'),
 		);

--- a/apps/api-server/src/modules/worldcup/worldcup.docs.ts
+++ b/apps/api-server/src/modules/worldcup/worldcup.docs.ts
@@ -67,11 +67,6 @@ export const ApiDocs: SwaggerMethodDoc<WorldcupController> = {
 			ApiBody({
 				type: SubmitWorldcupRequestDto,
 			}),
-			ApiResponse({
-				status: 200,
-				description: '',
-				type: WorldcupReseponseDto,
-			}),
 			ApiBearerAuth('Authorization'),
 		);
 	},

--- a/apps/api-server/src/modules/worldcup/worldcup.docs.ts
+++ b/apps/api-server/src/modules/worldcup/worldcup.docs.ts
@@ -34,6 +34,20 @@ export const ApiDocs: SwaggerMethodDoc<WorldcupController> = {
 			ApiBearerAuth('Authorization'),
 		);
 	},
+	getParticipatedWorldcup(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: '현재는 한 월드컵당 하나의 결과만 옴. 같은 월드컵 여러개 대응하게 수정해야함',
+			}),
+			ApiResponse({
+				status: 200,
+				description: '',
+				type: [WorldcupReseponseDto],
+			}),
+			ApiBearerAuth('Authorization'),
+		);
+	},
 	getWorldcupById(summary: string) {
 		return applyDecorators(
 			ApiOperation({
@@ -70,7 +84,7 @@ export const ApiDocs: SwaggerMethodDoc<WorldcupController> = {
 		return applyDecorators(
 			ApiOperation({
 				summary,
-				description: '유저의 월드컵 결과 제출',
+				description: '유저의 월드컵 결과 제출. 로그인 없이도 가능',
 			}),
 			ApiParam({
 				name: 'id',

--- a/apps/api-server/src/modules/worldcup/worldcup.module.ts
+++ b/apps/api-server/src/modules/worldcup/worldcup.module.ts
@@ -5,13 +5,11 @@ import { Drink } from '@src/entities/drinks.entity';
 import { WorldcupResultItem } from '@src/entities/worldcup-result-item.entity';
 import { WorldcupResult } from '@src/entities/worldcup-result.entity';
 import { Worldcup } from '@src/entities/worldcup.entity';
-import { DrinksModule } from '../drinks/drinks.module';
-import { DrinksService } from '../drinks/drinks.service';
 import { WorldcupController } from './worldcup.controller';
 import { WorldcupService } from './worldcup.service';
 
 @Module({
-	imports: [DrinksModule, TypeOrmModule.forFeature([Worldcup, WorldcupResult, WorldcupResultItem, Drink])],
+	imports: [TypeOrmModule.forFeature([Worldcup, WorldcupResult, WorldcupResultItem, Drink])],
 	controllers: [WorldcupController],
 	providers: [WorldcupService],
 })

--- a/apps/api-server/src/modules/worldcup/worldcup.module.ts
+++ b/apps/api-server/src/modules/worldcup/worldcup.module.ts
@@ -2,13 +2,16 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { Drink } from '@src/entities/drinks.entity';
+import { WorldcupResult } from '@src/entities/worldcup-result.entity';
 import { Worldcup } from '@src/entities/worldcup.entity';
+import { DrinksModule } from '../drinks/drinks.module';
+import { DrinksService } from '../drinks/drinks.service';
 import { WorldcupController } from './worldcup.controller';
-import { WolrdCupService } from './worldcup.service';
+import { WorldcupService } from './worldcup.service';
 
 @Module({
-	imports: [TypeOrmModule.forFeature([Worldcup, Drink])],
+	imports: [DrinksModule, TypeOrmModule.forFeature([Worldcup, WorldcupResult, Drink])],
 	controllers: [WorldcupController],
-	providers: [WolrdCupService],
+	providers: [WorldcupService],
 })
 export class WorldcupModule {}

--- a/apps/api-server/src/modules/worldcup/worldcup.module.ts
+++ b/apps/api-server/src/modules/worldcup/worldcup.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { Drink } from '@src/entities/drinks.entity';
+import { WorldcupResultItem } from '@src/entities/worldcup-result-item.entity';
 import { WorldcupResult } from '@src/entities/worldcup-result.entity';
 import { Worldcup } from '@src/entities/worldcup.entity';
 import { DrinksModule } from '../drinks/drinks.module';
@@ -10,7 +11,7 @@ import { WorldcupController } from './worldcup.controller';
 import { WorldcupService } from './worldcup.service';
 
 @Module({
-	imports: [DrinksModule, TypeOrmModule.forFeature([Worldcup, WorldcupResult, Drink])],
+	imports: [DrinksModule, TypeOrmModule.forFeature([Worldcup, WorldcupResult, WorldcupResultItem, Drink])],
 	controllers: [WorldcupController],
 	providers: [WorldcupService],
 })

--- a/apps/api-server/src/modules/worldcup/worldcup.service.ts
+++ b/apps/api-server/src/modules/worldcup/worldcup.service.ts
@@ -56,6 +56,11 @@ export class WorldcupService {
 	}
 
 	async submitWoldcupResult(worldcupId: number, drinkIds: number[], userId?: number) {
+		const worldcup = await this.worldcupRepository.findOneBy({ id: worldcupId });
+		if (!worldcup) {
+			throw new BadRequestException('존재하지 않는 월드컵입니다.');
+		}
+
 		const worldcupResult = await this.worldcupResultRepository.save({ userId, worldcupId });
 
 		const worldcupResultId = worldcupResult.id;

--- a/apps/api-server/src/modules/worldcup/worldcup.service.ts
+++ b/apps/api-server/src/modules/worldcup/worldcup.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { Repository } from 'typeorm';
@@ -7,11 +7,15 @@ import { WorldcupItemReseponseDto } from './dto/worldcup-item-response.dto';
 import { WorldcupReseponseDto } from './dto/worldcup-response.dto';
 import { Drink } from '@src/entities/drinks.entity';
 import { Worldcup } from '@src/entities/worldcup.entity';
+import { WorldcupResult } from '@src/entities/worldcup-result.entity';
+import { DrinksService } from '../drinks/drinks.service';
 
 @Injectable()
-export class WolrdCupService {
+export class WorldcupService {
 	constructor(
+		@Inject(DrinksService) private readonly drinkService: DrinksService,
 		@InjectRepository(Worldcup) private readonly worldcupRepository: Repository<Worldcup>,
+		@InjectRepository(WorldcupResult) private readonly worldcupResultRepository: Repository<WorldcupResult>,
 		@InjectRepository(Drink) private readonly drinkRepository: Repository<Drink>,
 	) {}
 
@@ -20,7 +24,7 @@ export class WolrdCupService {
 		return worldcups.map((worldcup) => new WorldcupReseponseDto(worldcup));
 	}
 
-	async getWolrdcupById(id): Promise<WorldcupReseponseDto> {
+	async getWorldcupById(id: number): Promise<WorldcupReseponseDto> {
 		const worldcup = await this.worldcupRepository.findOneBy({ id });
 		if (!worldcup) {
 			throw new BadRequestException('존재하지 않는 월드컵입니다.');
@@ -33,5 +37,35 @@ export class WolrdCupService {
 	async getWorldcupItemById(id: number, roundCount: number): Promise<any> {
 		const drinks = await this.drinkRepository.find({ relations: ['category'], take: roundCount });
 		return drinks.map((drink) => new WorldcupItemReseponseDto(drink));
+	}
+
+	async submitWoldcupResult(worldcupId: number, drinkIds: number[], userId?: number) {
+		const worldcupResults = drinkIds.map((drinkId, index) => {
+			const rankLevel = this.#getRankLevel(index);
+			return { userId, worldcupId, drinkId, rankLevel };
+		});
+
+		await this.worldcupResultRepository.save(worldcupResults);
+
+		const winnerDrinkId = drinkIds[0];
+		const winnerDrink = await this.drinkService.findDrinkById(winnerDrinkId);
+
+		return winnerDrink;
+	}
+
+	/**
+	 * 1등 -> 0
+	 * 2등 -> 1
+	 * 3~4등 -> 2
+	 * 5~8등 -> 3
+	 * 9~16등 -> 4
+	 * ...
+	 */
+	#getRankLevel(index: number, rankLevel = 0) {
+		if (index >> rankLevel === 0) {
+			return rankLevel;
+		}
+
+		return this.#getRankLevel(index, rankLevel + 1);
 	}
 }

--- a/apps/api-server/src/modules/worldcup/worldcup.service.ts
+++ b/apps/api-server/src/modules/worldcup/worldcup.service.ts
@@ -9,6 +9,7 @@ import { Drink } from '@src/entities/drinks.entity';
 import { Worldcup } from '@src/entities/worldcup.entity';
 import { WorldcupResult } from '@src/entities/worldcup-result.entity';
 import { DrinksService } from '../drinks/drinks.service';
+import { WorldcupResultItem } from '@src/entities/worldcup-result-item.entity';
 
 @Injectable()
 export class WorldcupService {
@@ -16,6 +17,8 @@ export class WorldcupService {
 		@Inject(DrinksService) private readonly drinkService: DrinksService,
 		@InjectRepository(Worldcup) private readonly worldcupRepository: Repository<Worldcup>,
 		@InjectRepository(WorldcupResult) private readonly worldcupResultRepository: Repository<WorldcupResult>,
+		@InjectRepository(WorldcupResultItem)
+		private readonly worldcupResultItemRepository: Repository<WorldcupResultItem>,
 		@InjectRepository(Drink) private readonly drinkRepository: Repository<Drink>,
 	) {}
 
@@ -40,12 +43,15 @@ export class WorldcupService {
 	}
 
 	async submitWoldcupResult(worldcupId: number, drinkIds: number[], userId?: number) {
-		const worldcupResults = drinkIds.map((drinkId, index) => {
+		const worldcupResult = await this.worldcupResultRepository.save({ userId, worldcupId });
+
+		const worldcupResultId = worldcupResult.id;
+		const worldcupResultItems = drinkIds.map((drinkId, index) => {
 			const rankLevel = this.#getRankLevel(index);
-			return { userId, worldcupId, drinkId, rankLevel };
+			return { worldcupResultId, drinkId, rankLevel };
 		});
 
-		await this.worldcupResultRepository.save(worldcupResults);
+		await this.worldcupResultItemRepository.save(worldcupResultItems);
 	}
 
 	/**

--- a/apps/api-server/src/modules/worldcup/worldcup.service.ts
+++ b/apps/api-server/src/modules/worldcup/worldcup.service.ts
@@ -1,21 +1,19 @@
 import { BadRequestException, ConsoleLogger, Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { EntityManager, getManager, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 
 import { WorldcupItemReseponseDto } from './dto/worldcup-item-response.dto';
 import { WorldcupReseponseDto } from './dto/worldcup-response.dto';
 import { Drink } from '@src/entities/drinks.entity';
 import { Worldcup } from '@src/entities/worldcup.entity';
 import { WorldcupResult } from '@src/entities/worldcup-result.entity';
-import { DrinksService } from '../drinks/drinks.service';
 import { WorldcupResultItem } from '@src/entities/worldcup-result-item.entity';
 import { WorldcupWithParticipantCountReseponseDto } from './dto/worldcup-with-participant-count-response.dto';
 
 @Injectable()
 export class WorldcupService {
 	constructor(
-		@Inject(DrinksService) private readonly drinkService: DrinksService,
 		@InjectRepository(Worldcup) private readonly worldcupRepository: Repository<Worldcup>,
 		@InjectRepository(WorldcupResult) private readonly worldcupResultRepository: Repository<WorldcupResult>,
 		@InjectRepository(WorldcupResultItem)

--- a/apps/api-server/src/modules/worldcup/worldcup.service.ts
+++ b/apps/api-server/src/modules/worldcup/worldcup.service.ts
@@ -46,11 +46,6 @@ export class WorldcupService {
 		});
 
 		await this.worldcupResultRepository.save(worldcupResults);
-
-		const winnerDrinkId = drinkIds[0];
-		const winnerDrink = await this.drinkService.findDrinkById(winnerDrinkId);
-
-		return winnerDrink;
 	}
 
 	/**


### PR DESCRIPTION
- [x] 월드컵 결과 제출 api
- [x] 인기 있는 월드컵 api 
- [x] 내가 참여한 월드컵 api

이번 피쳐엔 위 내용들을 작업했습니다. 

메인 피처 작업과 별개로 아래 사항들을 같이 작업했습니다
- drinkService를 export하지 않고 바로 외부 review모듈에서 사용하는 부분을 수정
- 토큰이 있다면 user정보를, 토큰이 없어도 401에러를 반환하지 않는 가드 추가(월드컵은 회원/비회원 모두 가능해서)

내가 참여한 월드컵에서 쿼리로 짜면 쉬운데 typeorm 메소드 구현으로는 막혀서 일단 TODO로 남겨두고 PR올립니다..ㅎ
휘리릭 해서 리뷰폭풍이 겁나네용 하하