### PR TITLE
Feat: Add drink to recommend

### DIFF
--- a/apps/api-server/src/modules/drinks/drinks.controller.ts
+++ b/apps/api-server/src/modules/drinks/drinks.controller.ts
@@ -32,6 +32,12 @@ export class DrinksController {
 		return await this.drinksService.findDrinksByCategory(name, page, length);
 	}
 
+	@Get('/recommend')
+	@ApiDocs.findDrinksToRecommend('추천 술 상세 정보 조회')
+	public async findDrinksToRecommend() {
+		return await this.drinksService.findDrinksToRecommend();
+	}
+
 	@Get(':id')
 	@ApiDocs.findDrinkById('특정 술 상세 정보 조회')
 	public async findDrinkById(@Param('id') id: number) {

--- a/apps/api-server/src/modules/drinks/drinks.docs.ts
+++ b/apps/api-server/src/modules/drinks/drinks.docs.ts
@@ -52,6 +52,19 @@ export const ApiDocs: SwaggerMethodDoc<DrinksController> = {
 			}),
 		);
 	},
+	findDrinksToRecommend(summary: string) {
+		return applyDecorators(
+			ApiOperation({
+				summary,
+				description: '추천 술 보기 or 요즘 사람들은 어떤 술을 마실까 - 리뷰 수 많은 순으로 최대 5개',
+			}),
+			ApiResponse({
+				status: 200,
+				description: '',
+				type: [DrinkDto],
+			}),
+		);
+	},
 	findUserReviewedDrinks(summary: string) {
 		return applyDecorators(
 			ApiOperation({

--- a/apps/api-server/src/modules/drinks/drinks.service.ts
+++ b/apps/api-server/src/modules/drinks/drinks.service.ts
@@ -78,6 +78,23 @@ export class DrinksService {
 		}
 	}
 
+	public async findDrinksToRecommend(): Promise<DrinkDto[]> {
+		try {
+			const drinksToRecommend = await this.drinkRepository
+				.createQueryBuilder('drink')
+				.select('drink.*, category.name as category, COUNT(*) as review_count')
+				.leftJoin('drink.reviews', 'review')
+				.leftJoin('drink.category', 'category')
+				.groupBy('drink.id, category.name')
+				.orderBy('review_count', 'DESC')
+				.limit(5)
+				.getRawMany();
+			return drinksToRecommend.map((drink) => new DrinkDto(drink));
+		} catch (error) {
+			throw new InternalServerErrorException(error.message, error);
+		}
+	}
+
 	public async findReviewedDrinksbyUser(userId: number): Promise<DrinkDto[]> {
 		try {
 			const userReviewedDrinks = await this.drinkRepository


### PR DESCRIPTION
홈 - DB 둘러보기에서 
요즘 사람들은 어떤 술을 마실까~와 추천 술 보기~에 사용될 api입니다. 
테이블 3개 join(drink, review, drinks-category)해서 group by 하는거 좀 서툴러서 자신이 없는데, 이 쿼리문보다 더 나은게 있다면 가감없이 조언 부탁드립니다. 

그리고 
이 PR과는 별개지만 약간 연관은 있어서 여기 남깁니다. 
지금 알아차렸는데, 술 정보 카드에 다 리뷰 통계에 대한 태그가 걸려있어야 하더라고요... 
<img width="207" alt="image" src="https://user-images.githubusercontent.com/55108539/185724693-7d706b0d-4af6-4ea5-8ae0-9663fcc0f4ce.png">
수민이가 작업한 내용이 술 정보들 줄 때도 필요할 거 같아요. api를 두 번 쏘게 할 건지, 아니면 service 코드에서 이것도 다 해결해서 줄 건지를 좀 생각해봐야 할 거 같아요. 


