### PR TITLE
Chore: use dynamic port to CD ecs cluster

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to Amazon ECS
 
 on:
     push:
-        branches: [main]
+        branches: [main, fix-dynamic-port]
 
 jobs:
     deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to Amazon ECS
 
 on:
     push:
-        branches: [main, fix-dynamic-port]
+        branches: [main]
 
 jobs:
     deploy:

--- a/apps/api-server/src/config/config.constant.ts
+++ b/apps/api-server/src/config/config.constant.ts
@@ -7,6 +7,9 @@ export type NodeEnv = 'dev' | 'integ' | 'test' | 'prod';
 export type AppConfig = {
 	env: NodeEnv;
 	listeningPort: number;
+	cors: {
+		origin: string[] | true; // TODO: Change to false after origins are fixed.
+	};
 };
 
 export type DatabaseConfig = {
@@ -33,6 +36,9 @@ export const appConfig = (): { appConfig: AppConfig } => ({
 	appConfig: {
 		env: process.env.NODE_ENV as NodeEnv,
 		listeningPort: +process.env.PORT || 3000,
+		cors: {
+			origin: process.env.CORS_ORIGIN ? process.env.CORS_ORIGIN.split(',') : true, // TODO: Change to false after origins are fixed.
+		},
 	},
 });
 

--- a/apps/api-server/src/main.ts
+++ b/apps/api-server/src/main.ts
@@ -13,6 +13,11 @@ async function bootstrap() {
 	const app = await NestFactory.create(AppModule);
 	const appConfig = app.get(ConfigService).get<AppConfig>('appConfig');
 	const port = appConfig.listeningPort;
+	app.enableCors({
+		origin: appConfig.cors.origin,
+		methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
+		credentials: true,
+	});
 
 	setupSwagger(app);
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"bcryptjs": "^2.4.3",
 		"class-transformer": "^0.5.1",
 		"class-validator": "^0.13.2",
+		"cors": "^2.8.5",
 		"dotenv": "^16.0.1",
 		"fast-csv": "^4.3.6",
 		"joi": "^17.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,7 @@ specifiers:
   bcryptjs: ^2.4.3
   class-transformer: ^0.5.1
   class-validator: ^0.13.2
+  cors: ^2.8.5
   cross-env: ^7.0.3
   dotenv: ^16.0.1
   eslint: ^7.30.0
@@ -74,6 +75,7 @@ dependencies:
   bcryptjs: 2.4.3
   class-transformer: 0.5.1
   class-validator: 0.13.2
+  cors: 2.8.5
   dotenv: 16.0.1
   fast-csv: 4.3.6
   joi: 17.6.0

--- a/task-definition.json
+++ b/task-definition.json
@@ -9,7 +9,7 @@
 			"image": "proof-backend-node-img",
 			"portMappings": [
 				{
-					"hostPort": 3000,
+					"hostPort": 0,
 					"protocol": "tcp",
 					"containerPort": 3000
 				}


### PR DESCRIPTION
## Problem
After CI/CD ecs deploy, there was a event 

```json
service proof-ecs-service was unable to place a task because no container instance met all of its requirements. The closest matching container-instance 106d4e49f25d43b48b3363931a7201ae is already using a port required by your task. For more information, see the Troubleshooting section.
```

## Solving
 [https://aws.amazon.com/premiumsupport/knowledge-center/ecs-container-instance-requirement-error/](https://aws.amazon.com/premiumsupport/knowledge-center/ecs-container-instance-requirement-error/)

- The port needed by tha task is already in use
    - If the port required by the task is in use, then [add container instances to your cluster](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_container_instance.html), or reduce your number of desired tasks.**Note:** If possible, consider using [dynamic port mapping](https://aws.amazon.com/premiumsupport/knowledge-center/dynamic-port-mapping-ecs/)to allow your tasks to use any available port on a container instance.
    - [https://aws.amazon.com/premiumsupport/knowledge-center/dynamic-port-mapping-ecs/](https://aws.amazon.com/premiumsupport/knowledge-center/dynamic-port-mapping-ecs/)


dynamic port 사용으로 ecs rolling update CD 되도록 하였습니다. 
https://github.com/mash-up-kr/proof_Backend_Node/runs/7998210648?check_suite_focus=true 에서 잘 되는 것 확인했어요. 

이거 머지되고 나면 한 번 더 main branch 로 PR, merge 해서 ECS 배포 하려고 해요. 

리뷰 받는 동안 저는 http -> https 하겠습니다. 

### 그 외로, 
Cors 설정을 추가했습니다. 어떤 origin 주소가 추가될지 몰라서 일단 origin list들 | true 로 해놓긴 했는데, 
확정되고 나면 origin list들 | false 로 수정 하려고 합니다. 
그래도 일단 env file에 'CORS_ORIGIN=웹팀주소'를 추가해주시면 됩니다.~
