### PR TITLE
Chore: 월드컵 seed데이터 중복insert 방지

### DIFF
--- a/apps/api-server/src/database/seeds/worldcup.seed.ts
+++ b/apps/api-server/src/database/seeds/worldcup.seed.ts
@@ -408,6 +408,6 @@ export default class WorldcupSeed implements Seeder {
 			},
 		];
 
-		await connection.createQueryBuilder().insert().into(Worldcup).values(insertValues).execute();
+		await connection.createQueryBuilder().insert().into(Worldcup).values(insertValues).orIgnore().execute();
 	}
 }

--- a/apps/api-server/src/entities/worldcup.entity.ts
+++ b/apps/api-server/src/entities/worldcup.entity.ts
@@ -1,11 +1,12 @@
 import { IsString } from 'class-validator';
-import { Column, Entity } from 'typeorm';
+import { Column, Entity, Unique } from 'typeorm';
 
 import { WorldcupRoundDto } from '@src/modules/worldcup/dto/worldcup.dto';
 import { CommonEntity } from './common.entity';
 import { WorldcupResult } from './worldcup-result.entity';
 
 @Entity()
+@Unique('wolrdcup_unique_keys', ['withWhoCode', 'situationCode'])
 export class Worldcup extends CommonEntity {
 	@IsString()
 	@Column()


### PR DESCRIPTION
typeORM에도 upsert 메소드를 지원해주지만, @PrimaryGeneratedColumn 데코레이터를 사용할 시는 적용이 되지 않아 별도의 유니크 키를 지정하고 중복될 시, ignore해주도록 하였습니다